### PR TITLE
Adds endpoint to download all data

### DIFF
--- a/backend/app/routers/statistics.py
+++ b/backend/app/routers/statistics.py
@@ -471,10 +471,20 @@ async def download_all(
                         async for chunk in result.body_iterator:
                             str_fp.write(chunk)
 
+                        # get the human-readable name of the model (aka the
+                        # measure category), if available, and default to the
+                        # model's simple name if not
+                        try:
+                            model_name = model.Config.label or simple_model_name
+                        except AttributeError:
+                            model_name = simple_model_name
+
+                        # produce a human-readable name for the measure, if available,
+                        # from the MEASURE_DESCRIPTIONS entry for this model
                         final_name = f"{get_or_key(model_measure_labels, measure)}.csv"
 
                         z.writestr(
-                            os.path.join(type, simple_model_name, final_name),
+                            os.path.join(type, model_name, final_name),
                             str_fp.getvalue()
                         )
 

--- a/backend/app/routers/statistics.py
+++ b/backend/app/routers/statistics.py
@@ -3,12 +3,14 @@ API endpoints that return statistics, e.g. cancer incidence/mortality,
 or sociodemographic measures.
 """
 
+import os
 import csv
-from io import StringIO
+from io import StringIO, BytesIO
+import zipfile
 
 from typing import Optional, Annotated
 from fastapi import Depends, Query, HTTPException, APIRouter
-from fastapi.responses import StreamingResponse
+from fastapi.responses import StreamingResponse, FileResponse
 from pydantic import BaseModel
 from sqlalchemy import func
 from sqlmodel import select
@@ -17,6 +19,7 @@ from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlmodel import paginate
 
 from tools.strings import slugify, slug_modelname_sans_type
+from tools.accessors import get_or_key, get_keys
 from db import get_session
 
 from settings import LIMIT_TO_STATE
@@ -144,8 +147,6 @@ async def get_measures(session: AsyncSession = Depends(get_session)):
 # --- model-specific routes
 # ----------------------------------------------------------------
 
-# generates a set of stats endpoints per model from the STATS_MODELS dict
-
 def parse_filter_str(filters):
     """
     Takes a string of the form "<factor1>:<value1>;<factor2>:<value2>;..." and
@@ -164,6 +165,10 @@ def parse_filter_str(filters):
 
 class FactorsFilter(BaseModel):
     factors : dict[str,str]
+
+# collects a set of routes for downloading each model as a CSV
+# since we're going to compile them all into a zip
+download_routes = []
 
 # the loop below creates routes dynamically from the models specified in the
 # STATS_MODELS dict; we get one set of routes per model in that dict
@@ -342,15 +347,12 @@ for type, family in STATS_MODELS.items():
                 # (they'll be added as columns to the output)
                 factor_labels = FACTOR_DESCRIPTIONS.get(simple_model_name, None)
 
-                def label_for_measure(measure):
-                    return model_measure_labels.get(measure, measure) or measure
-
                 def model_to_fields(x, factor_labels):
                     fields = [
                         x["GEOID"],
                         x["County"],
                         x["State"],
-                        label_for_measure(x["measure"]),
+                        get_or_key(model_measure_labels, x["measure"]),
                         x["value"],
                     ]
 
@@ -399,10 +401,85 @@ for type, family in STATS_MODELS.items():
                     )
 
                     response = StreamingResponse(iter([fp.getvalue()]), media_type="text/csv")
-                    response.headers["Content-Disposition"] = f"attachment; filename=COE_{slugify(measure or simple_model_name)}_{type}.csv"
+                    response.headers["Content-Disposition"] = f"attachment; filename=ECCO_{slugify(measure or simple_model_name)}_{type}.csv"
 
                     return response
+            
+            # append the endpoint to the download_routes dict; we'll
+            # iterate over this later to produce a set of all possible
+            # downloadable CSVs
+            download_routes.append({
+                'type': type,
+                'model': model,
+                'route': download_dataset
+            })
             
         # finally, execute the generate_routes() method closed over the
         # 'type', 'model', and 'simple_model_name' vars
         generate_routes()
+
+
+# ============================================================================
+# === aggregate download route(s)
+# ============================================================================
+
+# ----------------------------------------------------------------
+# --- a CSV-formatted version of the model for downloading
+# ----------------------------------------------------------------
+@router.get(
+    f"/download-all",
+    response_class=StreamingResponse,
+    description=f"""
+    Produces a CSV of each stats model, then adds them all to a zip file and
+    returns the zip file for download.
+    """
+)
+async def download_all(
+    session: AsyncSession = Depends(get_session)
+):
+    with BytesIO() as zip_fp:
+        with zipfile.ZipFile(zip_fp, "w") as z:
+            # iterate over the download_routes dict and add each CSV to the zip
+            for route_info in download_routes:
+                type, model, route = get_keys(route_info, "type", "model", "route")
+                simple_model_name = slug_modelname_sans_type(model, type)
+
+                # get human labels for measures within this model, if available
+                model_measure_labels = MEASURE_DESCRIPTIONS.get(simple_model_name, {})
+
+                # retrieve the measures for the model, depending on what type of model it is
+                if model in CANCER_MODELS:
+                    query = select(model.Site).distinct().order_by(model.Site)
+                else:
+                    query = select(model.measure).distinct().order_by(model.measure)
+
+                measures_result = await session.execute(query)
+                measures = measures_result.scalars().all()
+
+                # iterate over the measures for each model
+                for measure in measures:
+                    # query the download csv endpoint
+                    result = await route(measure=measure, session=session)
+
+                    # if you want to parse out the filename, you'd do it like so:
+                    # filename = result.headers["Content-Disposition"].split("filename=", maxsplit=1)[1]
+                    # (but at the moment we're overriding the filename with what
+                    # we know it should be.)
+
+                    # read the response into a buffer, then write it into the zip
+                    with StringIO() as str_fp:
+                        async for chunk in result.body_iterator:
+                            str_fp.write(chunk)
+
+                        final_name = f"{get_or_key(model_measure_labels, measure)}.csv"
+
+                        z.writestr(
+                            os.path.join(type, simple_model_name, final_name),
+                            str_fp.getvalue()
+                        )
+
+        # stream the finished zip back to the user           
+        response = StreamingResponse(iter([zip_fp.getvalue()]), media_type="application/zip")
+        response.headers["Content-Disposition"] = f"attachment; filename=ECCO_All_Measures.zip"
+
+        return response

--- a/backend/app/tools/accessors.py
+++ b/backend/app/tools/accessors.py
@@ -1,0 +1,24 @@
+""""
+Helper methods for interacting with dicts and other data
+structures in Python
+"""
+
+def get_or_key(target, key):
+    """
+    Get a value from a target dict-like or return the key if it doesn't exist
+    or is falsey.
+    """
+    return target.get(key, key) or key
+
+def get_keys(d, *k):
+    """
+    Get the values corresponding to the given keys in the provided dict.
+
+    This can be used in a destructuring assignment from a dict into variables,
+    e.g. for a dict {'a': 1, 'b': 2, 'c': 3} you could extract the values of 'a'
+    and 'b' with `a, b = dictget(d, 'a', 'b')`.
+
+    >>> dictget({'a': 1, 'b': 2, 'c': 3}, 'a', 'b')
+    (1, 2)
+    """
+    return [d[i] for i in k]

--- a/backend/app/tools/strings.py
+++ b/backend/app/tools/strings.py
@@ -1,3 +1,4 @@
+import os
 import re
 import unicodedata
 
@@ -18,3 +19,53 @@ def slug_modelname_sans_type(model, type):
     slugifying the result.
     """
     return slugify(model.__name__.lower().replace(type, ""))
+
+# from sanitize-filename, but i decided against taking a dep on the package
+# https://gitlab.com/jplusplus/sanitize-filename/-/raw/master/sanitize_filename/sanitize_filename.py?ref_type=heads
+def sanitize(filename):
+    """Return a fairly safe version of the filename.
+
+    We don't limit ourselves to ascii, because we want to keep municipality
+    names, etc, but we do want to get rid of anything potentially harmful,
+    and make sure we do not exceed Windows filename length limits.
+    Hence a less safe blacklist, rather than a whitelist.
+
+    (From https://gitlab.com/jplusplus/sanitize-filename)
+    """
+    blacklist = ["\\", "/", ":", "*", "?", "\"", "<", ">", "|", "\0"]
+    reserved = [
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5",
+        "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5",
+        "LPT6", "LPT7", "LPT8", "LPT9",
+    ]  # Reserved words on Windows
+    filename = "".join(c for c in filename if c not in blacklist)
+    # Remove all charcters below code point 32
+    filename = "".join(c for c in filename if 31 < ord(c))
+    filename = unicodedata.normalize("NFKD", filename)
+    filename = filename.rstrip(". ")  # Windows does not allow these at end
+    filename = filename.strip()
+    if all([x == "." for x in filename]):
+        filename = "__" + filename
+    if filename in reserved:
+        filename = "__" + filename
+    if len(filename) == 0:
+        filename = "__"
+    if len(filename) > 255:
+        parts = re.split(r"/|\\", filename)[-1].split(".")
+        if len(parts) > 1:
+            ext = "." + parts.pop()
+            filename = filename[:-len(ext)]
+        else:
+            ext = ""
+        if filename == "":
+            filename = "__"
+        if len(ext) > 254:
+            ext = ext[254:]
+        maxl = 255 - len(ext)
+        filename = filename[:maxl]
+        filename = filename + ext
+        # Re-check last character (if there was no extension)
+        filename = filename.rstrip(". ")
+        if len(filename) == 0:
+            filename = "__"
+    return filename

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -198,6 +198,11 @@ export function getDownload(level: string, category: string, measure?: string) {
   }`;
 }
 
+/** get download all link */
+export function getDownloadAll() {
+  return `${api}/stats/download-all`;
+}
+
 /** location geojson properties fields */
 type LocationProps = {
   name?: string;

--- a/frontend/src/pages/PageSources.vue
+++ b/frontend/src/pages/PageSources.vue
@@ -671,5 +671,6 @@
 <script setup lang="ts">
 import { faTable } from "@fortawesome/free-solid-svg-icons";
 import { getDownloadAll } from "@/api";
+import AppButton from "@/components/AppButton.vue";
 import AppLink from "@/components/AppLink.vue";
 </script>

--- a/frontend/src/pages/PageSources.vue
+++ b/frontend/src/pages/PageSources.vue
@@ -2,15 +2,6 @@
   <section>
     <h2>Sources</h2>
 
-    <AppButton
-      v-tooltip="'Download all sources data in CSV format'"
-      :icon="faTable"
-      :to="getDownloadAll()"
-      :accent="true"
-    >
-      Download All Data
-    </AppButton>
-
     <p>
       Data for ECCO were gathered from several publicly available sources. Due
       to automated data collection efforts, years on sources will change over
@@ -20,6 +11,17 @@
         >Cancer InFocus: Catchment Areas</AppLink
       >. The complete years of data reflected in ECCO vary by source. Data will
       be updated as the most recent data becomes available.
+    </p>
+
+    <p class="center">
+      <AppButton
+        v-tooltip="'Download all sources data in CSV format'"
+        :icon="faTable"
+        :to="getDownloadAll()"
+        :accent="true"
+      >
+        Download All Data
+      </AppButton>
     </p>
   </section>
 

--- a/frontend/src/pages/PageSources.vue
+++ b/frontend/src/pages/PageSources.vue
@@ -2,6 +2,15 @@
   <section>
     <h2>Sources</h2>
 
+    <AppButton
+      v-tooltip="'Download all sources data in CSV format'"
+      :icon="faTable"
+      :to="getDownloadAll()"
+      :accent="true"
+    >
+      Download All Data
+    </AppButton>
+
     <p>
       Data for ECCO were gathered from several publicly available sources. Due
       to automated data collection efforts, years on sources will change over
@@ -660,5 +669,7 @@
 </template>
 
 <script setup lang="ts">
+import { faTable } from "@fortawesome/free-solid-svg-icons";
+import { getDownloadAll } from "@/api";
 import AppLink from "@/components/AppLink.vue";
 </script>


### PR DESCRIPTION
This PR introduces a new API endpoint, `/stats/download-all`, that returns a ZIP file to the user of all the measures served on the site.

Closes #8.

The ZIP file has the following structure:
- type (either "county" or "tract")
  - measure category (e.g., "Cancer Mortality (age-adj per 100k)")
    - measure CSVs (e.g., "Esophagus.csv")

The names for the measure category folders and measure files should match what is displayed in the frontend. This probably isn't a big concern, but we might consider either sanitizing them or changing to their internal IDs if we anticipate that future CancerInFocus updates will introduce characters that aren't allowed in filenames.

Internally, it iterates over all the individual CSV-downloading endpoints and queries them individually, compiling the result into a ZIP file which is then streamed to the user. All this is currently done in memory, which should be fine considering the resulting uncompressed ZIP file is ~10MB.