### PR TITLE
More frontend improvements

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,7 +1,6 @@
 VITE_PRETITLE=University of Colorado Cancer Center's 
 VITE_TITLE=Exploring Cancer in Colorado
 VITE_DESCRIPTION=Explore and visualize cancer data in the Colorado area.
-VITE_AREA=Colorado
 VITE_LOGO_LINK=https://medschool.cuanschutz.edu/colorado-cancer-center
 VITE_SOURCE_CODE=https://github.com/colorado-cancer-center/ecco
 VITE_LICENSE=https://github.com/colorado-cancer-center/ecco/blob/main/LICENSE

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,6 +1,7 @@
 import * as d3 from "d3";
 import type { FeatureCollection, Geometry } from "geojson";
 import { mapValues, omitBy } from "lodash";
+import type { ExplicitScale } from "@/components/AppMap.vue";
 import cancerCenterLocations from "./cancer-center-locations.json";
 import cancerInFocusLocations from "./cancer-in-focus-locations.json";
 
@@ -45,7 +46,7 @@ type _Data = {
 }[];
 
 /** data geojson properties fields */
-type DataProps = {
+export type DataProps = {
   id: string | number | undefined;
   name: string;
   full?: string | undefined;
@@ -188,7 +189,12 @@ export async function getValues(
   /** if missing data, return empty */
   if (!values.length) return;
 
-  return stats;
+  /** define explicit scale for certain data */
+  let explicitScale: ExplicitScale;
+  if (category.includes("trend"))
+    explicitScale = { 1: "Falling", 2: "Stable", 3: "Rising" };
+
+  return { ...stats, explicitScale };
 }
 
 export type Values = Awaited<ReturnType<typeof getValues>>;
@@ -206,7 +212,7 @@ export function getDownloadAll() {
 }
 
 /** location geojson properties fields */
-type LocationProps = {
+export type LocationProps = {
   name?: string;
   org?: string;
   link?: string;

--- a/frontend/src/components/AppAlert.vue
+++ b/frontend/src/components/AppAlert.vue
@@ -30,7 +30,7 @@ const dismissed = ref(false);
   display: flex;
   position: relative;
   flex-direction: column;
-  padding: 30px max(40px, (100% - 800px) / 2);
+  padding: 30px max(40px, (100% - 1000px) / 2);
   gap: 10px;
   background: var(--theme-light);
 }

--- a/frontend/src/components/AppMap.vue
+++ b/frontend/src/components/AppMap.vue
@@ -113,19 +113,19 @@
 
       <div class="mini-table">
         <!-- primary "value" for feature -->
-        <template v-if="featureInfo.value">
+        <template v-if="featureInfo.value !== undefined">
           <span>
             {{ featureInfo.aac ? "Rate" : "Value" }}
           </span>
           <span>{{
             typeof featureInfo.value === "number"
-              ? formatValue(featureInfo.value || 0, percent, false)
+              ? formatValue(featureInfo.value, percent, false)
               : featureInfo.value
           }}</span>
         </template>
 
         <!-- average annual count -->
-        <template v-if="featureInfo.aac">
+        <template v-if="featureInfo.aac !== undefined">
           <span>Avg. Annual Count</span>
           <span>{{ formatValue(featureInfo.aac, false, false) }}</span>
         </template>
@@ -356,7 +356,7 @@ function bindPopup(layer: L.Layer) {
       if (props.explicitScale) info.value = props.explicitScale[value.value];
       else {
         info.value = value.value;
-        info.aac = value.aac || undefined;
+        info.aac = value.aac ?? undefined;
       }
     }
     featureInfo.value = info;
@@ -407,7 +407,7 @@ const scale = computed(() => {
       });
 
     /** explicit color */
-    const getColor = (value: keyof typeof props.explicitScale) =>
+    const getColor = (value?: keyof typeof props.explicitScale) =>
       steps.find((step) => step.value === value)?.color || noDataColor;
 
     return { steps, getColor };
@@ -472,8 +472,8 @@ const scale = computed(() => {
     }
 
     /** scale interpolator */
-    const getColor = (value: number) =>
-      value < min || value > max
+    const getColor = (value?: number) =>
+      value === undefined
         ? noDataColor
         : d3.scaleQuantile<string>().domain(bands).range(colors)(value);
 
@@ -659,7 +659,7 @@ function updateColors() {
   getLayers<L.GeoJSON>("data", L.GeoJSON).forEach((layer) =>
     layer.setStyle((feature) => ({
       fillColor: scale.value.getColor(
-        props.values?.[feature?.properties.id]?.value || 0,
+        props.values?.[feature?.properties.id]?.value,
       ),
     })),
   );

--- a/frontend/src/components/AppMap.vue
+++ b/frontend/src/components/AppMap.vue
@@ -100,66 +100,66 @@
     </Teleport>
 
     <!-- county/tract popup -->
-    <Teleport v-if="popup && popupFeature" :to="popup">
+    <Teleport v-if="popup && featureInfo" :to="popup">
       <!-- name -->
-      <template v-if="popupFeature.name">
-        <strong>{{ popupFeature.name }}</strong>
+      <template v-if="featureInfo.name">
+        <strong>{{ featureInfo.name }}</strong>
       </template>
 
       <!-- id -->
-      <template v-if="popupFeature.fips">
-        <strong>Census Tract<br />{{ popupFeature.fips }}</strong>
+      <template v-if="featureInfo.fips">
+        <strong>Census Tract<br />{{ featureInfo.fips }}</strong>
       </template>
 
       <div class="mini-table">
         <!-- primary "value" for feature -->
-        <template v-if="values[popupFeature.id]">
+        <template v-if="featureInfo.value">
+          <span>
+            {{ featureInfo.aac ? "Rate" : "Value" }}
+          </span>
           <span>{{
-            typeof values[popupFeature.id]?.aac === "number" ? "Rate" : "Value"
-          }}</span>
-          <span>{{
-            formatValue(values[popupFeature.id]?.value || 0, percent, false)
+            typeof featureInfo.value === "number"
+              ? formatValue(featureInfo.value || 0, percent, false)
+              : featureInfo.value
           }}</span>
         </template>
 
         <!-- average annual count -->
-        <template v-if="typeof values[popupFeature.id]?.aac === 'number'">
+        <template v-if="featureInfo.aac">
           <span>Avg. Annual Count</span>
-          <span>{{
-            formatValue(values[popupFeature.id]?.aac || 0, false, false)
-          }}</span>
+          <span>{{ formatValue(featureInfo.aac, false, false) }}</span>
         </template>
 
         <!-- organization -->
-        <template v-if="popupFeature.org">
+        <template v-if="featureInfo.org">
           <span>Org</span>
-          <span>{{ popupFeature.org }}</span>
+          <span>{{ featureInfo.org }}</span>
         </template>
 
         <!-- link -->
-        <template v-if="popupFeature.link">
+        <template v-if="featureInfo.link">
           <span>Link</span>
-          <AppLink :to="popupFeature.link" class="truncate">
-            {{ popupFeature.link.replace(/(https?:\/\/)?(www\.)?/, "") }}
+          <AppLink :to="featureInfo.link" class="truncate">
+            {{ featureInfo.link.replace(/(https?:\/\/)?(www\.)?/, "") }}
           </AppLink>
         </template>
 
         <!-- address -->
-        <template v-if="popupFeature.address">
+        <template v-if="featureInfo.address">
           <span>Address</span>
-          <span>{{ popupFeature.address }}</span>
+          <span>{{ featureInfo.address }}</span>
         </template>
 
         <!-- phone -->
-        <template v-if="popupFeature.phone">
+        <template v-if="featureInfo.phone">
           <span>Phone</span>
-          <span>{{ popupFeature.phone }}</span>
+          <span>{{ featureInfo.phone }}</span>
         </template>
 
         <!-- notes -->
-        <template v-if="popupFeature.notes">
+        <template v-if="featureInfo.notes">
           <span>Notes</span>
-          <span>{{ popupFeature.notes }}</span>
+          <span>{{ featureInfo.notes }}</span>
         </template>
       </div>
     </Teleport>
@@ -177,9 +177,8 @@ import {
 } from "vue";
 import * as d3 from "d3";
 import domtoimage from "dom-to-image";
-import type { GeoJsonProperties } from "geojson";
 import L, { type MapOptions } from "leaflet";
-import { debounce, isEmpty, mapValues } from "lodash";
+import { cloneDeep, debounce, isEmpty, mapValues } from "lodash";
 import {
   faCropSimple,
   faDownload,
@@ -188,7 +187,7 @@ import {
   faPlus,
 } from "@fortawesome/free-solid-svg-icons";
 import { useElementSize, useFullscreen, useResizeObserver } from "@vueuse/core";
-import type { Data, Locations, Values } from "@/api";
+import type { Data, DataProps, LocationProps, Locations, Values } from "@/api";
 import AppButton from "@/components/AppButton.vue";
 import AppLink from "@/components/AppLink.vue";
 import { getGradient } from "@/components/gradient";
@@ -198,6 +197,8 @@ import { downloadPng } from "@/util/download";
 import { formatValue, isPercent, normalizedApply } from "@/util/math";
 import { getBbox, sleep } from "@/util/misc";
 import "leaflet/dist/leaflet.css";
+
+export type ExplicitScale = Props["explicitScale"];
 
 /** "no data" color */
 let noDataColor = "#a0a0a0";
@@ -280,8 +281,12 @@ const bottomRightLegend = ref<HTMLElement>();
 /** element to teleport popup template content to */
 const popup = ref<HTMLElement>();
 
-/** properties of selected feature for popup */
-const popupFeature = ref<GeoJsonProperties>();
+type Info = Partial<
+  DataProps & LocationProps & { value: number | string; aac: number }
+>;
+
+/** info about selected feature for popup */
+const featureInfo = ref<Info>();
 
 /** https://leafletjs.com/reference.html#map-option */
 const mapOptions: MapOptions = {
@@ -331,15 +336,31 @@ function getLayers<T extends L.Layer = L.Layer>(
 function bindPopup(layer: L.Layer) {
   layer.bindPopup(() => "");
   layer.on("popupopen", async (event) => {
-    const wrapper = event.popup
-      .getElement()
-      ?.querySelector<HTMLElement>(".leaflet-popup-content-wrapper");
-    if (!wrapper) return;
-    wrapper.innerHTML = "";
-    popup.value = wrapper || undefined;
+    popup.value =
+      event.popup
+        .getElement()
+        ?.querySelector<HTMLElement>(".leaflet-popup-content-wrapper") ||
+      undefined;
+    if (!popup.value) return;
+    popup.value.innerHTML = "";
     /** wait for popup to teleport */
     await nextTick();
-    popupFeature.value = event.sourceTarget.feature.properties;
+
+    /**
+     * set info for selected feature. clone to avoid weird proxy linking
+     * effects.
+     */
+    const info: Info = cloneDeep(event.sourceTarget.feature.properties);
+    const value = props.values[info.id || ""];
+    if (value) {
+      if (props.explicitScale) info.value = props.explicitScale[value.value];
+      else {
+        info.value = value.value;
+        info.aac = value.aac || undefined;
+      }
+    }
+    featureInfo.value = info;
+
     /** wait for popup to populate to full size before updating position */
     await nextTick();
     event.popup.update();
@@ -347,9 +368,12 @@ function bindPopup(layer: L.Layer) {
   layer.on("popupclose", () => {
     /** unset popup */
     popup.value = undefined;
-    popupFeature.value = undefined;
+    featureInfo.value = undefined;
   });
 }
+
+/** close popups (which could contain stale data) any time props change */
+watch(props, () => map?.closePopup(), { deep: true });
 
 /** whether map has any "no data" regions */
 const noData = computed(

--- a/frontend/src/pages/PageAbout.vue
+++ b/frontend/src/pages/PageAbout.vue
@@ -20,6 +20,35 @@
       of the map as an image.
     </p>
 
+    <AppHeading level="3">Acknowledge</AppHeading>
+
+    <p>
+      If you find this site useful in your academic or research work, we ask
+      that you acknowledge it as a source in your publications, presentations,
+      or other materials. Suggested acknowledgement:
+    </p>
+
+    <blockquote>
+      Cancer statistics and information were obtained from ECCO ({{ url }}),
+      accessed on [DATE], and supported by the University of Colorado Cancer
+      Center Support Grant (P30CA046934).
+    </blockquote>
+
+    <p>
+      By acknowledging our site, you help support our ongoing efforts to provide
+      accurate and up-to-date cancer statistics to the public, researchers, and
+      healthcare professionals. Your acknowledgement also helps others locate
+      the source of the information, promoting transparency and facilitating
+      further research.
+    </p>
+
+    <p>
+      If you have any questions or require additional information for your
+      acknowledgement, please feel free to
+      <AppLink to="#contact">contact us</AppLink>. Thank you for your
+      cooperation and for using our site.
+    </p>
+
     <AppHeading level="3">Contact</AppHeading>
 
     <p>
@@ -27,7 +56,7 @@
       help, please contact us:
     </p>
 
-    <p class="actions">
+    <div class="buttons">
       <AppButton
         :icon="faGithub"
         to="https://github.com/colorado-cancer-center/ecco/issues/new/choose"
@@ -36,7 +65,7 @@
       <AppButton :icon="faEnvelope" to="mailto:jan.lowery@cuanschutz.edu"
         >Email</AppButton
       >
-    </p>
+    </div>
   </section>
 </template>
 
@@ -45,4 +74,7 @@ import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import AppButton from "@/components/AppButton.vue";
 import AppHeading from "@/components/AppHeading.vue";
+import AppLink from "@/components/AppLink.vue";
+
+const { VITE_URL: url } = import.meta.env;
 </script>

--- a/frontend/src/pages/PageHome.vue
+++ b/frontend/src/pages/PageHome.vue
@@ -1,7 +1,7 @@
 <template>
   <AppAlert>
     <p>
-      <i>This site is still under development</i>. Please
+      <strong>This site is still under development</strong>. Please
       <AppLink to="/about#contact">let us know how we can improve it</AppLink>!
       ECCO is intended to support research, community inquiries, and outreach
       activities. It should not be used to guide clinical decisions.
@@ -767,12 +767,14 @@ const _locations = computed(
   () => pick(locations.value, selectedLocations.value) as Locations | undefined,
 );
 
-/** auto-update manual min/max */
 watchEffect(() => {
-  if (manualMinMax.value) return;
-  const { min, max } = values.value || {};
-  if (min !== undefined) manualMin.value = min;
-  if (max !== undefined) manualMax.value = max;
+  /** if manual min/max off */
+  if (!manualMinMax.value) {
+    /** keep in sync with actual min/max (nicer UX when turning manual on) */
+    const { min, max } = values.value || {};
+    if (min !== undefined) manualMin.value = min;
+    if (max !== undefined) manualMax.value = max;
+  }
 });
 
 /** auto-adjust map height */

--- a/frontend/src/pages/PageHome.vue
+++ b/frontend/src/pages/PageHome.vue
@@ -279,11 +279,7 @@
         :scale-steps="scaleSteps"
         :nice-steps="niceSteps"
         :scale-power="scalePower"
-        :explicit-scale="
-          selectedCategory.includes('trend')
-            ? { 1: 'Falling', 2: 'Stable', 3: 'Rising' }
-            : undefined
-        "
+        :explicit-scale="values?.explicitScale"
         :width="mapWidth"
         :height="mapHeight"
         :filename="[selectedMeasure, selectedLevel]"
@@ -354,9 +350,16 @@
       prevention, screening, treatment, survivorship, and more.
     </p>
 
-    <div class="center">
+    <div class="buttons">
       <AppButton to="/about" :icon="faArrowRight" :flip="true" :accent="true"
         >Learn more</AppButton
+      >
+      <AppButton
+        to="/about#acknowledge"
+        :icon="faArrowRight"
+        :flip="true"
+        :accent="true"
+        >Acknowledge Us</AppButton
       >
     </div>
   </section>

--- a/frontend/src/pages/PageHome.vue
+++ b/frontend/src/pages/PageHome.vue
@@ -1,13 +1,10 @@
 <template>
   <AppAlert>
     <p>
-      This site is still in <strong>beta</strong>. Please
-      <AppLink to="/about#contact">let us know how we can improve it!</AppLink>
-    </p>
-    <p>
-      We encourage using this for non-critical applications of research,
-      outreach, and similar purposes. It should not be used to support clinical
-      decisions.
+      <i>This site is still under development</i>. Please
+      <AppLink to="/about#contact">let us know how we can improve it</AppLink>!
+      ECCO is intended to support research, community inquiries, and outreach
+      activities. It should not be used to guide clinical decisions.
     </p>
   </AppAlert>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -151,8 +151,17 @@ small {
 }
 
 p {
-  line-height: var(--spacing);
   text-align: justify;
+}
+
+p,
+ul,
+ol,
+table,
+blockquote,
+pre {
+  margin: 0.75lh 0;
+  line-height: var(--spacing);
 }
 
 strong {
@@ -186,11 +195,21 @@ td {
   text-align: left;
 }
 
+tr:last-child td {
+  border: none;
+}
+
+blockquote {
+  padding: 10px 30px;
+  border-left: solid 2px var(--light-gray);
+  font-style: italic;
+}
+
 .center {
   text-align: center;
 }
 
-.actions {
+.buttons {
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -41,3 +41,8 @@ declare module "leaflet" {
     ): TileLayer.Provider;
   }
 }
+
+declare module "*.vue" {
+  import Vue from "vue";
+  export default Vue;
+}

--- a/frontend/src/util/math.ts
+++ b/frontend/src/util/math.ts
@@ -8,10 +8,16 @@ export function formatValue(
 ): string {
   if (percent) return round(value * 100, compact ? 1 : 3) + "%";
   else
-    return value.toLocaleString(undefined, {
-      notation: compact ? "compact" : undefined,
-      maximumFractionDigits: 2,
-    });
+    return value.toLocaleString(
+      undefined,
+      compact
+        ? {
+            notation: "compact",
+            maximumFractionDigits: 2,
+            maximumSignificantDigits: 3,
+          }
+        : undefined,
+    );
 }
 
 /** check if range is within 0-1 and should be treated as percent */

--- a/frontend/src/util/math.ts
+++ b/frontend/src/util/math.ts
@@ -11,7 +11,6 @@ export function formatValue(
     return value.toLocaleString(undefined, {
       notation: compact ? "compact" : undefined,
       maximumFractionDigits: 2,
-      minimumFractionDigits: value % 1 < 0.0001 ? 1 : undefined,
     });
 }
 

--- a/frontend/src/util/math.ts
+++ b/frontend/src/util/math.ts
@@ -10,7 +10,8 @@ export function formatValue(
   else
     return value.toLocaleString(undefined, {
       notation: compact ? "compact" : undefined,
-      maximumFractionDigits: Math.abs(value) < 1 ? 2 : undefined,
+      maximumFractionDigits: 2,
+      minimumFractionDigits: value % 1 < 0.0001 ? 1 : undefined,
     });
 }
 


### PR DESCRIPTION
- move setting of explicit scale into api funcs
- rename popupFeature to featureInfo and simplify its types
- when there is an explicit scale, have popup show the value's string label instead of numeric value
- add acknowledgement section on about page and link from home page
- style tweaks
- make sure 0 values show in feature popup
- make scale "getColor" accept undefined for "no data", and when calling it, don't fallback to 0
- rename "show stats" to "show extras", and include selected factors in legend when checked
- add manual min/max controls. closes #49 
- hide irrelevant controls when selected measure has an "explicit scale"
- add safety try/catch so if loading values fails for some reason, they reset. prevents case where user changes a selection, loading fails, and still shows most recent successful data (stale, from a different selection).
- simplify dynamic factor watcher again. fix bug where going from measure that has factors back to a measure with no factors makes a bad request (regression from #58 i think)
- debounce map height fit for better browser performance
- update formatValue again