### PR TITLE
Changing over to coe-ecco.org

### DIFF
--- a/.env.TEMPLATE
+++ b/.env.TEMPLATE
@@ -1,4 +1,6 @@
-DOMAIN_NAMES=
+DOMAIN_NAMES="api.coe-ecco.org coe-ecco.org ecco.cu-dbmi.dev co-cancer-scope.cu-dbmi.dev"
+FRONTEND_DOMAIN="coe-ecco.org"
+API_DOMAIN="api.coe-ecco.org"
 ADMIN_EMAIL=
 
 POSTGRES_DATABASE="ecco"
@@ -6,3 +8,5 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=
 POSTGRES_PORT=5432
 POSTGRES_HOST=db
+
+MAPS_API_KEY=

--- a/.env.TEMPLATE
+++ b/.env.TEMPLATE
@@ -1,6 +1,7 @@
 DOMAIN_NAMES="api.coe-ecco.org coe-ecco.org ecco.cu-dbmi.dev co-cancer-scope.cu-dbmi.dev"
 FRONTEND_DOMAIN="coe-ecco.org"
 API_DOMAIN="api.coe-ecco.org"
+PRIMARY_DOMAIN="api.coe-ecco.org"
 ADMIN_EMAIL=
 
 POSTGRES_DATABASE="ecco"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ import aiomcache
 
 from routers import geometry, statistics
 
-from settings import IS_DEV
+from settings import IS_DEV, FRONTEND_DOMAIN
 
 # we'll just allow all origins for the time being
 ALLOW_ALL_ORIGINS = True
@@ -22,6 +22,7 @@ app = FastAPI()
 origins = [
     "http://localhost",
     "http://localhost:8001",
+    f"https://{FRONTEND_DOMAIN}"
 ]
 
 app.add_middleware(

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -3,4 +3,6 @@ import os
 IS_DEV=os.environ.get("IS_DEV", "") in ("1", "True", "true")
 DATABASE_URL=os.environ.get("DATABASE_URL")
 
+FRONTEND_DOMAIN=os.environ.get("FRONTEND_DOMAIN")
+
 LIMIT_TO_STATE = "Colorado"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - built_frontend:/app/build/
     environment:
-      - "VITE_API=https://ecco.cu-dbmi.dev/api"
+      - "VITE_API=https://api.coe-ecco.org/"
 
   nginx-certbot:
     # image: nginx:1.19.6-alpine

--- a/frontend/.env
+++ b/frontend/.env
@@ -5,5 +5,5 @@ VITE_AREA=Colorado
 VITE_LOGO_LINK=https://medschool.cuanschutz.edu/colorado-cancer-center
 VITE_SOURCE_CODE=https://github.com/colorado-cancer-center/ecco
 VITE_LICENSE=https://github.com/colorado-cancer-center/ecco/blob/main/LICENSE
-VITE_URL=https://ecco.cu-dbmi.dev
-VITE_API=https://ecco.cu-dbmi.dev/api
+VITE_URL=https://coe-ecco.org
+VITE_API=https://api.coe-ecco.org

--- a/services/nginx-certbot/Dockerfile
+++ b/services/nginx-certbot/Dockerfile
@@ -13,6 +13,8 @@ COPY ./config/ssl-options/options-ssl-nginx.conf /etc/nginx-conf/ssl-options/opt
 COPY ./entrypoint.sh /var/entrypoint.sh
 COPY ./config/templates/ /etc/nginx/templates/
 
+COPY ./scripts/renew_cert_reload.sh /var/scripts/renew_cert_reload.sh
+
 # override the entrypoint to first start cron, then nginx
 # ENTRYPOINT [ "/var/entrypoint.sh" ]
 

--- a/services/nginx-certbot/config/templates/default.conf.template
+++ b/services/nginx-certbot/config/templates/default.conf.template
@@ -9,10 +9,10 @@ upstream backend {
     server backend:8000;
 }
 
-# HTTPS configuration
+# HTTPS configuration, frontend
 server {
     listen 443 ssl;
-    server_name ${DOMAIN_NAMES};
+    server_name ${FRONTEND_DOMAIN};
 
     ssl_certificate /etc/letsencrypt/live/${PRIMARY_DOMAIN}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${PRIMARY_DOMAIN}/privkey.pem;
@@ -41,17 +41,36 @@ server {
         index index.html;
         try_files $uri /index.html;
     }
+}
+
+# HTTP configuration, backend
+server {
+    listen 443 ssl;
+    server_name ${API_DOMAIN};
+
+    ssl_certificate /etc/letsencrypt/live/${PRIMARY_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${PRIMARY_DOMAIN}/privkey.pem;
+
+    include /etc/nginx-conf/ssl-options/options-ssl-nginx.conf;
+    # ssl_dhparam /etc/nginx-conf/ssl-options/ssl-dhparams.pem;
+
+    charset utf-8;
+    client_max_body_size 10M;   # max upload size
+
+    gzip             on;
+    gzip_comp_level  3;
+    gzip_types       text/plain application/xml application/json;
+
+    # allow certbot to respond to ACME challenges
+    location /.well-known/acme-challenge/ {
+        proxy_pass http://localhost;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
 
     # backend
-    location = /api {
-        absolute_redirect off;
-        return 302 /api/;
-    }
-    location = /openapi.json {
-        proxy_pass http://backend;
-        proxy_http_version 1.1;
-    }
-    location /api/ {
+    location / {
         proxy_pass http://backend/;
         proxy_http_version 1.1;
 

--- a/services/nginx-certbot/entrypoint.sh
+++ b/services/nginx-certbot/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-export PRIMARY_DOMAIN=$(echo $DOMAIN_NAME | cut -d' ' -f1)
+# used by, e.g., nginx to find the certs, since the first name in
+# the list of domains is used to name the cert folder
+export PRIMARY_DOMAIN=$(echo $DOMAIN_NAMES | cut -d' ' -f1)
 
 cron && /docker-entrypoint.sh "$@"

--- a/services/nginx-certbot/scripts/renew_cert_reload.sh
+++ b/services/nginx-certbot/scripts/renew_cert_reload.sh
@@ -11,3 +11,6 @@ certbot certonly \
     --nginx --non-interactive --agree-tos \
     --email ${ADMIN_EMAIL} ${DOMAIN_ARGS} --expand && \
 nginx -s reload
+
+# to manually do a DNS-01 challenge
+# certbot certonly --force-renewal --manual --preferred-challenges dns --email ${ADMIN_EMAIL} ${DOMAIN_ARGS} --expand


### PR DESCRIPTION
This PR introduces a few backend changes to accommodate running the frontent at coe-ecco.org via Netlify and the API server at api.coe-ecco.org.

Specifically, the nginx configuration in `default.conf` has been split into two server blocks:
- one that handles `api.coe-ecco.org` and redirects to the backend, and
- the other handles `coe-ecco.org` and serves the built frontend bundle.

I added `api.coe-ecco.org` and `coe-ecco.org` to the list of domains in `DOMAIN_NAMES`. The result is that Let's Encrypt assigns the first value in the list, e.g. `api.coe-ecco.org`, as the "canonical name" and uses that domain as the name of the folder in which it stores keys. The other domain names are registered as Subject Alternative Names on the same certificate, meaning that certificate satisfies requests for those domain names as well.

Because `coe-ecco.org` currently points to Netlify, we can't perform HTTP-01 challenges for that domain; I manually performed a DNS-01 challenge for that domain for now, but if we're committed to Netlify I could simply drop it from domain list, and I'd likely also remove building and serving the frontend from the stack entirely.

I also added a few env vars related to the separate domains:
- `API_DOMAIN` is used by nginx to determine the hostname to direct to the backend
- `FRONTEND_DOMAIN` is used by nginx the same way, but for the frontend
- `PRIMARY_DOMAIN` specifies the first entry in `DOMAIN_NAMES`
  - it shouldn't be necessary to specify it here since the nginx container's entrypoint script should set it as an env var by extracting it from `DOMAIN_NAMES`, but for some reason it wasn't propagating into nginx's template substitution layer, so I just pulled it out as an env var for now.