### PR TITLE
Re-allows ecco.cu-dbmi.dev to serve both the frontend and backend

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,7 +14,6 @@ services:
       - "VITE_URL=https://ecco.cu-dbmi.dev"
       - "VITE_API=https://ecco.cu-dbmi.dev/api"
 
-
   nginx-certbot:
     # image: nginx:1.19.6-alpine
     build: ./services/nginx-certbot/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,9 @@ services:
     volumes:
       - built_frontend:/app/build/
     environment:
-      - "VITE_API=https://api.coe-ecco.org/"
+      - "VITE_URL=https://ecco.cu-dbmi.dev"
+      - "VITE_API=https://ecco.cu-dbmi.dev/api"
+
 
   nginx-certbot:
     # image: nginx:1.19.6-alpine

--- a/services/nginx-certbot/config/templates/default.conf.template
+++ b/services/nginx-certbot/config/templates/default.conf.template
@@ -35,6 +35,29 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    # still serve the backend if it's explicitly requested at /api
+    # as well as other backend-specific resources
+    location = /api {
+        absolute_redirect off;
+        return 302 /api/;
+    }
+    location = /openapi.json {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+    }
+    location /api/ {
+        proxy_pass http://backend/;
+        proxy_http_version 1.1;
+
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        # needed for websockets(?)
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+
     # frontend
     location / {
         root /usr/share/nginx/html;


### PR DESCRIPTION
When we transitioned from `ecco.cu-dbmi.dev` to `coe-ecco.org`, I made some changes that disabled the backend from being served from `ecco.cu-dbmi.dev`. This PR partially reverses those changes, so that `coe-ecco.org` served from Netlify can still access `api.coe-ecco.org`, and `ecco.cu-dbmi.dev` served from our `ecco` VM will now query `ecco.cu-dbmi.dev/api`.

In detail, this PR does the following:
- Instructs the frontend that's built on the `ecco` VM to consider itself served from `ecco.cu-dbmi.dev` and to query the API at `ecco.cu-dbmi.dev/api`
- Sets up nginx to allow backend access at `/api/` again

I've tested that `coe-ecco.org` still works (it hits `api.coe-ecco.org`, which is still served from the `ecco` VM via its own server block, selected by hostname). I did a quick test on https://ecco.cu-dbmi.dev and verified that it also works: the frontend is querying `ecco.cu-dbmi.dev/api`, as it should, the backend is getting hit, and it's responding.