### PR TITLE
Adds units to API response

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,5 +1,7 @@
 import os
 
+from typing import AsyncGenerator
+
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
@@ -16,7 +18,7 @@ async def init_db():
         await conn.run_sync(SQLModel.metadata.create_all)
 
 
-async def get_session() -> AsyncSession:
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async_session = sessionmaker(
         engine, class_=AsyncSession, expire_on_commit=False
     )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -34,10 +34,5 @@ from .cif import (
     SociodemographicsTract,
     DisparitiesTract,
 )
-from .scp import (
-    SCPDeathsCounty,
-    SCPIncidenceCounty
-)
-from .disparity_index import (
-    CancerDisparitiesIndex
-)
+from .scp import SCPDeathsCounty, SCPIncidenceCounty
+from .disparity_index import CancerDisparitiesIndex

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -77,7 +77,7 @@ class MeasureUnit(Enum):
     RANK = "rank" # a position in a ranking
     ORDINAL = "ordinal" # a discrete value that can be ordered, e.g. "rising" (1), "falling" (2), "stable" (3)
     CATEGORICAL = "categorical" # a discrete value that *can't* be ordered, e.g. "white", "black", "hispanic"
-    RATIO = "ratio" # range from -1 to +1, where -1 is "least affected" and +1 is "most affected". 
+    RATIO = "ratio" # range from -1 to +1, where -1 is "least affected" and +1 is "most affected"
 
 
 from .cif import (

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -3,6 +3,7 @@ Base classes for models, originally derived from cancerinfocus.org ("cif")
 but used elsewhere now, e.g. for the disparities index.
 """
 
+from enum import Enum
 from typing import Optional
 
 from sqlmodel import Field, SQLModel
@@ -52,17 +53,49 @@ class CancerStatsByCounty(BaseStatsModel):
         return ()
 
 class MeasuresByTract(MeasuresByCounty):
-    Tract : Optional[str] = Field(index=True, nullable=True)
+    Tract: Optional[str] = Field(index=True, nullable=True)
 
-# aggregate metadata for all measure-type models
+
+# ---------------------------------------------------------------------------
+# -- metadata about the models
+# ---------------------------------------------------------------------------
+
+
+class MeasureUnit(Enum):
+    """
+    The unit of measurement for a given measure, exposed as the 'unit' field in the API
+    endpoint's fips-values response.
+
+    The 'ratio' unit is a bit complicated; see https://cancerinfocus.org/datasources/, specifically the
+    indices of segregation for examples.
+    """
+
+    PERCENT = "percent" # a percentage; the datasets we use encode these as floats between 0 and 1, inclusive
+    COUNT = "count" # raw count, represented as an integer, e.g. number of cases
+    RATE = "rate" # rate of occurrence, represented as a float and typically normalized by population
+    DOLLAR_AMOUNT = "dollar_amount" # raw dollar amount, e.g. income
+    RANK = "rank" # a position in a ranking
+    ORDINAL = "ordinal" # a discrete value that can be ordered, e.g. "rising" (1), "falling" (2), "stable" (3)
+    CATEGORICAL = "categorical" # a discrete value that *can't* be ordered, e.g. "white", "black", "hispanic"
+    RATIO = "ratio" # range from -1 to +1, where -1 is "least affected" and +1 is "most affected". 
+
+
 from .cif import (
     STATS_MODELS as CIF_STATS_MODELS,
     CIF_CANCER_MODELS,
-    MEASURE_DESCRIPTIONS as CIF_MEASURE_DESCRIPTIONS,
+    CIF_MEASURE_DESCRIPTIONS,
     CIF_FACTOR_DESCRIPTIONS
 )
-from .disparity_index import DISPARITY_INDEX_MODELS
-from .scp import SCP_MODELS, SCP_MEASURE_DESCRIPTIONS, SCP_FACTOR_DESCRIPTIONS, SCP_CANCER_MODELS
+from .disparity_index import (
+    DISPARITY_INDEX_MODELS,
+    DISPARITY_INDEX_MEASURE_DESCRIPTIONS,
+)
+from .scp import (
+    SCP_MODELS,
+    SCP_MEASURE_DESCRIPTIONS,
+    SCP_FACTOR_DESCRIPTIONS,
+    SCP_CANCER_MODELS,
+)
 
 STATS_MODELS = {
     "county": (
@@ -86,7 +119,8 @@ CANCER_MODELS = set.union(SCP_CANCER_MODELS, CIF_CANCER_MODELS)
 
 MEASURE_DESCRIPTIONS = {
     **CIF_MEASURE_DESCRIPTIONS,
-    **SCP_MEASURE_DESCRIPTIONS
+    **SCP_MEASURE_DESCRIPTIONS,
+    **DISPARITY_INDEX_MEASURE_DESCRIPTIONS
 }
 
 FACTOR_DESCRIPTIONS = {

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -77,7 +77,7 @@ class MeasureUnit(Enum):
     RANK = "rank" # a position in a ranking
     ORDINAL = "ordinal" # a discrete value that can be ordered, e.g. "rising" (1), "falling" (2), "stable" (3)
     CATEGORICAL = "categorical" # a discrete value that *can't* be ordered, e.g. "white", "black", "hispanic"
-    RATIO = "ratio" # range from -1 to +1, where -1 is "least affected" and +1 is "most affected"
+    LEAST_MOST = "least_most" # range from -1 to +1, where -1 is "least affected" and +1 is "most affected"
 
 
 from .cif import (

--- a/backend/app/models/cif.py
+++ b/backend/app/models/cif.py
@@ -10,13 +10,14 @@ from .base import BaseStatsModel, MeasuresByCounty, CancerStatsByCounty, Measure
 # === stats models from CIF data export
 # ===========================================================================
 
+
 class CIFCancerStatsByCounty(CancerStatsByCounty):
     # 'Type' is always Incidence for CancerIncidenceCounty, Mortality for CancerMortalityCounty
     # so it's not terribly useful...
-    Type : str = Field(index=True)
+    Type: str = Field(index=True)
     # demographic data, added sometime in february 2024(?)
-    RE : str = Field(index=True, nullable=True)
-    Sex : str = Field(index=True, nullable=True)
+    RE: str = Field(index=True, nullable=True)
+    Sex: str = Field(index=True, nullable=True)
 
     @classmethod
     def get_factors(cls):
@@ -29,6 +30,7 @@ class CIFCancerStatsByCounty(CancerStatsByCounty):
 
 # county cancer measures
 
+
 class CancerIncidenceCounty(CIFCancerStatsByCounty, table=True):
     class Config:
         label = "Cancer Incidence (age-adj per 100k)"
@@ -39,6 +41,7 @@ class CancerIncidenceCounty(CIFCancerStatsByCounty, table=True):
     # measure : str = synonym("Site")
     # value : float = synonym("AAR")
 
+
 class CancerMortalityCounty(CIFCancerStatsByCounty, table=True):
     class Config:
         label = "Cancer Mortality (age-adj per 100k)"
@@ -47,57 +50,72 @@ class CancerMortalityCounty(CIFCancerStatsByCounty, table=True):
     # measure : str = synonym("Site")
     # value : float = synonym("AAR")
 
+
 # county general measures
+
 
 class EconomyCounty(MeasuresByCounty, table=True):
     class Config:
         label = "Economics & Insurance"
 
+
 class EnvironmentCounty(MeasuresByCounty, table=True):
     class Config:
         label = "Environment"
+
 
 class HousingTransCounty(MeasuresByCounty, table=True):
     class Config:
         label = "Housing & Transportation"
 
+
 class RfAndScreeningCounty(MeasuresByCounty, table=True):
     class Config:
         label = "Screening & Risk Factors"
+
 
 class SociodemographicsCounty(MeasuresByCounty, table=True):
     class Config:
         label = "Sociodemographics"
 
+
 class DisparitiesCounty(MeasuresByCounty, table=True):
     class Config:
         label = "Disparities"
 
+
 # tract general measures
+
 
 class EconomyTract(MeasuresByTract, table=True):
     class Config:
         label = "Economics & Insurance"
 
+
 class EnvironmentTract(MeasuresByTract, table=True):
     class Config:
         label = "Environment"
+
 
 class FoodDesertTract(MeasuresByTract, table=True):
     class Config:
         label = "Food Deserts"
 
+
 class HousingTransTract(MeasuresByTract, table=True):
     class Config:
         label = "Housing & Transportation"
+
 
 class RfAndScreeningTract(MeasuresByTract, table=True):
     class Config:
         label = "Screening & Risk Factors"
 
+
 class SociodemographicsTract(MeasuresByTract, table=True):
     class Config:
         label = "Sociodemographics"
+
 
 class DisparitiesTract(MeasuresByTract, table=True):
     class Config:
@@ -109,7 +127,12 @@ class DisparitiesTract(MeasuresByTract, table=True):
 # === (e.g. creating routes automatically, adding human-readable labels)
 # ===========================================================================
 
-CIF_CANCER_MODELS = { CancerIncidenceCounty, CancerMortalityCounty }
+CIF_CANCER_MODELS = {CancerIncidenceCounty, CancerMortalityCounty}
+
+# NOTE: the CancerIncidenceCounty and CancerMortalityCounty models are
+# commented out below because they're superseded by the SCPDeathsCounty
+# and SCPIncidenceCounty models. i didn't remove them entirely because
+# we might want to switch back at some point, or at least compare them.
 
 STATS_MODELS = {
     "county": [
@@ -129,334 +152,9 @@ STATS_MODELS = {
         FoodDesertTract,
         HousingTransTract,
         RfAndScreeningTract,
-        DisparitiesTract
-    ]
+        DisparitiesTract,
+    ],
 }
 
-MEASURE_DESCRIPTIONS = {
-    "sociodemographics": {
-        "18 to 64": "18 to 64 Years Old",
-        "Advanced Degree": "Completed a Graduate Degree",
-        "Asian": "Asian (non-Hispanic)",
-        "Below 9th grade": "Below 9th grade",
-        "Black": "Black (non-Hispanic)",
-        "College": "Graduated College",
-        "High School": "Graduated High School",
-        "Hispanic": "Hispanic",
-        "Lack_English_Prof": "Lack Proficiency in English",
-        "Other_Races": "Other Non-Hispanic Race",
-        "Over 64": "Over 64 Years Old",
-        "Total": "Total Population",
-        "Under 18": "Under 18 Years Old",
-        "Urban_Percentage": "Urbanized Residents",
-        "White": "White (non-Hispanic)"
-        # Total Population
-        # Under 18 Years Old
-        # 18 to 64 Years Old
-        # Over 64 Years Old
-        # White (non-Hispanic)
-        # Black (non-Hispanic)
-        # Hispanic
-        # Asian (non-Hispanic)
-        # Other Non-Hispanic Race
-        # Did Not Attend High School
-        # Graduated High School
-        # Graduated College
-        # Completed a Graduate Degree
-        # Urbanized Residents
-        # Lack Proficiency in English
-    },
-    "economy": {
-        "Annual Labor Force Participation Rate": "Annual Labor Force Participation",
-        "Annual Unemployment Rate": "Annual Unemployment Rate",
-        "Below Poverty": "Living Below Poverty",
-        "Gini Coefficient": "Income Inequality (Gini Coefficient)",
-        "Household Income": "Household Income ($)",
-        "Insurance Coverage": "Insured",
-        "Medicaid Enrollment": "Enrolled in Medicaid",
-        "Monthly Unemployment Rate (Apr)": "Monthly Unemployment Rate", # ???
-        "Received Public Assistance": "Received TANF or SNAP Public Assistance",
-        "Uninsured": "Uninsured",
-        # Annual Labor Force Participation
-        # Annual Unemployment Rate
-        # Enrolled in Medicaid
-        # Household Income ($)
-        # Income Inequality (Gini Coefficient)
-        # Insured
-        # Living Below Poverty
-        # Received TANF or SNAP Public Assistance
-        # Uninsured
-    },
-    "environment": {
-        "LILATracts_Vehicle": "Tracts that are Food Deserts",
-        "PWS_Violations_Since_2016": "Public Water System Violations since 2016",
-        # Public Water System Violations since 2016
-        # Tracts that are Food Deserts
-    },
-    "housingtrans": {
-        "Crowded Housing": "Crowded Homes",
-        "Lack Complete Plumbing": "Homes without Complete Plumbing",
-        "Median Gross Rent": "Median Gross Rent ($)",
-        "Median Home Value": "Median Home Value ($)",
-        "Median Monthly Mortgage": "Median Monthly Mortgage ($)",
-        "Mobile Homes": "Housing in Mobile Homes",
-        "Multi-Unit Structures": "Housing in Multi-Unit Structures",
-        "No Home Broadband": "Homes without Broadband Internet",
-        "No Vehicle": "No Household Vehicle Access",
-        "Owner Occupied Housing": "Owner-occupied Housing Units",
-        "Rent Burden (40% Income)": "High Rent Burden",
-        "Single Parent Household": "Single Parent Homes",
-        "Vacancy Rate": "Vacant Housing"
-        # Crowded Homes
-        # High Rent Burden
-        # Homes without Broadband Internet
-        # Homes without Complete Plumbing
-        # Housing in Mobile Homes
-        # Housing in Multi-Unit Structures
-        # Median Gross Rent ($)
-        # Median Home Value ($)
-        # Median Monthly Mortgage ($)
-        # No Household Vehicle Access
-        # Owner-occupied Housing Units
-        # Single Parent Homes
-        # Vacant Housing
-    },
-    "rfandscreening": {
-        "Asthma": "Diagnosed with Asthma",
-        "Bad_Health": "Report Fair or Poor Overall Health",
-        "Binge_Drinking": "Binge Drink",
-        "BMI_Obese": "Obese (BMI over 30)",
-        "BP_Medicine": "On Blood Pressure Medication",
-        "Cancer_Prevalence": "History of Cancer Diagnosis",
-        "CHD": "Have Coronary Heart Disease",
-        "COPD": "Have COPD",
-        "Currently_Smoke": "Currently Smoke",
-        "Depression": "Have Depression",
-        "Diabetes_DX": "Diagnosed with Diabetes",
-        "Had_Stroke": "Had a Stroke",
-        "High_BP": "Have High Blood Pressure",
-        "Kidney_Disease": "Have Chronic Kidney Disease",
-        "Met_Breast_Screen": "Met Breast Screening Recommendations",
-        "Met_Cervical_Screen": "Met Cervical Screening Recommendations",
-        "Met_Colon_Screen": "Met Colorectal Screening Recommendations",
-        "No_Teeth": "All Adult Teeth Lost",
-        "Physically_Inactive": "Physically Inactive",
-        "Poor_Mental": "Report Frequent Mental Health Distress",
-        "Poor_Physical": "Report Frequent Physical Health Distress",
-        "Recent_Checkup": "Had a Medical Checkup in the Last Year",
-        "Recent_Dentist": "Had a Dental Visit in the Last Year",
-        "Sleep_Debt": "Sleep < 7 Hours a Night",
-
-        # NOTE: in the KY site, rfandscreening seems to be split between
-        #  "Screening & Risk Factors" and "Other Health Factors" but in
-        #  the data they're merged into rfandscreening (akak "Screening & Risk
-        #  Factors")
-
-        # labels from "Screening & Risk Factors" category on the KY site
-        # - Met Breast Screening Recommendations
-        # - Had Pap Test in Last 3 Years, Age 21-64
-        # - Met Colorectal Screening Recommendations
-        # - Currently Smoke (adults)
-        # - Obese (BMI over 30)
-        # - Physical Inactive
-        # - Binge Drink
-        # - Sleep < 7 Hours a Night
-        # - History of Cancer Diagnosis
-
-        # labels from "Other Health Factors" category
-        # - Report Fair or Poor Overall Health
-        # - Report Frequent Physical Health Distress
-        # - Report Frequent Mental Health Distress
-        # - Have Depression
-        # - Diagnosed with Diabetes
-        # - Have High Blood Pressure
-        # - On Blood Pressure Medication
-        # - Have Coronary Heart Disease
-        # - Had a Stroke
-        # - Have Chronic Kidney Disease
-        # - Diagnosed with Asthma
-        # - Have COPD
-        # - All Adult Teeth Lost
-        # - Had a Medical Checkup in the Last Year
-        # - Had a Dental Visit in the Last Year
-    },
-    "fooddesert": {
-        "LILATracts_Vehicle": "Tracts that are Food Deserts",
-    },
-
-    "disparities": {
-        "Living Below Poverty (Black)": "Black Population Living Below Poverty",
-        "Uninsured (Black)": "Black Population without Health Insurance",
-        "Uninsured Children": "Children without Health Insurance",
-        "Economic Segregation": "Economic Segregation",
-        "Gender Pay Gap": "Gender Pay Gap",
-        "Living Below Poverty (Hispanic)": "Hispanic Population Living Below Poverty",
-        "Uninsured (Hispanic)": "Hispanic Population without Health Insurance",
-        "Gini Coefficient": "Income Inequality (Gini Coefficient)",
-        "Racial Economic Segregation": "Racial Economic Segregation",
-        "Racial Segregation": "Racial Segregation",
-        "Lack_English_Prof": "Lack Proficiency in English"
-    },
-    
-    # on the KY site, there are many more measures than in the data we have
-    # available. above, we only include the ones that are present in the data.
-
-    "cancerincidence": {
-        "All Site": "All Cancer Sites",
-        "Bladder": "",
-        "Brain & ONS": "",
-        "Cervix": "",
-        "Colon & Rectum": "",
-        "Corpus Uteri & Uterus, NOS": "",
-        "Esophagus": "",
-        "Female Breast": "",
-        "Kidney & Renal Pelvis": "",
-        "Leukemia": "",
-        "Liver & IBD": "",
-        "Lung & Bronchus": "",
-        "Melanoma of the Skin": "",
-        "Non-Hodgkin Lymphoma": "",
-        "Oral Cavity & Pharynx": "",
-        "Ovary": "",
-        "Pancreas": "",
-        "Prostate": "",
-        "Stomach": "",
-        "Thyroid": "",
-
-    },
-    "cancermortality": {
-        "All Site": "All Cancer Sites",
-        "Bladder": "",
-        "Brain & ONS": "",
-        "Cervix": "",
-        "Colon & Rectum": "",
-        "Corpus Uteri & Uterus, NOS": "",
-        "Esophagus": "",
-        "Female Breast": "",
-        "Kidney & Renal Pelvis": "",
-        "Leukemia": "",
-        "Liver & IBD": "",
-        "Lung & Bronchus": "",
-        "Melanoma of the Skin": "",
-        "Non-Hodgkin Lymphoma": "",
-        "Oral Cavity & Pharynx": "",
-        "Ovary": "",
-        "Pancreas": "",
-        "Prostate": "",
-        "Stomach": "",
-        "Thyroid": "",
-    }
-
-    # from KY site:
-    # cancer incidence labels:
-    # - All Cancer Sites
-    # - Bladder Cancer
-    # - Brain Cancer
-    # - Cervical Cancer
-    # - Colorectal Cancer
-    # - Esophageal Cancer
-    # - Female Breast Cancer
-    # - Hodgkin Lymphoma
-    # - Kidney Cancer
-    # - Laryngeal Cancer
-    # - Leukemia
-    # - Liver Cancer
-    # - Lung Cancer
-    # - Melanoma
-    # - Myeloma
-    # - Non-Hodgkin Lymphoma
-    # - Oral Cavity and Pharynx Cancer
-    # - Ovarian Cancer
-    # - Pancreatic Cancer
-    # - Prostate Cancer
-    # - Stomach Cancer
-    # - Thyroid Cancer
-    # - Uterine Cancer
-    # - Uterine, NOS Cancer
-
-    # cancer mortality labels:
-    # - All Cancer Sites
-    # - Bladder Cancer
-    # - Brain Cancer
-    # - Cervical Cancer
-    # - Colorectal Cancer
-    # - Esophageal Cancer
-    # - Female Breast Cancer
-    # - Hodgkin Lymphoma
-    # - Kidney Cancer
-    # - Laryngeal Cancer
-    # - Leukemia
-    # - Liver Cancer
-    # - Lung Cancer
-    # - Melanoma
-    # - Myeloma
-    # - Non-Hodgkin Lymphoma
-    # - Oral Cavity and Pharynx Cancer
-    # - Ovarian Cancer
-    # - Pancreatic Cancer
-    # - Prostate Cancer
-    # - Stomach Cancer
-    # - Thyroid Cancer
-    # - Uterine Cancer
-    # - Uterine, NOS Cancer
-}
-
-# descriptions of factors, i.e. additional enumerated values associated
-# with each record. for example, cancer stats have race/ethnicity and sex
-# associated with them, and can be filtered by those values.
-# the 'default' field identifies which value is used if the user doesn't
-# supply one when querying.
-# format:
-# {
-#  <model name>: {
-#   <field id>: {
-#     label: <field label>,
-#     default: <default val>,
-#     values: { <value>: <label> }
-#   }, ...
-#  }, ...
-# }
-CIF_FACTOR_DESCRIPTIONS = {
-    "cancerincidence": {
-        "RE": {
-            "label": "Race/Ethnicity",
-            "default": "All",
-            "values": {
-                "All": "All",
-                "Black NH": "Black (non-Hispanic)",
-                "Hispanic": "Hispanic",
-                "White NH": "White (Non-Hispanic)"
-            }
-        },
-        "Sex": {
-            "label": "Sex",
-            "default": "All",
-            "values": {
-                "All": "All",
-                "Female": "Female",
-                "Male": "Male"
-            }
-        }
-    },
-    "cancermortality": {
-        "RE": {
-            "label": "Race/Ethnicity",
-            "default": "All",
-            "values": {
-                "All": "All",
-                "Black NH": "Black (non-Hispanic)",
-                "Hispanic": "Hispanic",
-                "White NH": "White (Non-Hispanic)"
-            }
-        },
-        "Sex": {
-            "label": "Sex",
-            "default": "All",
-            "values": {
-                "All": "All",
-                "Female": "Female",
-                "Male": "Male"
-            }
-        }
-    }
-}
+# imported from base.py to build the app's full metadata collection
+from .cif_meta import CIF_MEASURE_DESCRIPTIONS, CIF_FACTOR_DESCRIPTIONS

--- a/backend/app/models/cif_meta.py
+++ b/backend/app/models/cif_meta.py
@@ -295,7 +295,7 @@ CIF_MEASURE_DESCRIPTIONS = {
         },
         "Economic Segregation": {
             "label": "Economic Segregation",
-            "unit": MeasureUnit.PERCENT,
+            "unit": MeasureUnit.RATIO,
         },
         "Gender Pay Gap": {
             "label": "Gender Pay Gap",
@@ -315,11 +315,11 @@ CIF_MEASURE_DESCRIPTIONS = {
         },
         "Racial Economic Segregation": {
             "label": "Racial Economic Segregation",
-            "unit": MeasureUnit.PERCENT,
+            "unit": MeasureUnit.RATIO,
         },
         "Racial Segregation": {
             "label": "Racial Segregation",
-            "unit": MeasureUnit.PERCENT,
+            "unit": MeasureUnit.RATIO,
         },
         "Lack_English_Prof": {
             "label": "Lack Proficiency in English",

--- a/backend/app/models/cif_meta.py
+++ b/backend/app/models/cif_meta.py
@@ -1,0 +1,647 @@
+"""
+Holds metadata for models defined in cif.py
+
+(Other modules store the metadata alongside the models, but the CIF
+data is so verbose that i decided to split it into a separate module.)
+"""
+
+from .base import MeasureUnit
+
+CIF_MEASURE_DESCRIPTIONS = {
+    "sociodemographics": {
+        "18 to 64": {
+            "label": "18 to 64 Years Old",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Advanced Degree": {
+            "label": "Completed a Graduate Degree",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Asian": {
+            "label": "Asian (non-Hispanic)",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Below 9th grade": {
+            "label": "Below 9th grade",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Black": {
+            "label": "Black (non-Hispanic)",
+            "unit": MeasureUnit.PERCENT
+        },
+        "College": {
+            "label": "Graduated College",
+            "unit": MeasureUnit.PERCENT
+        },
+        "High School": {
+            "label": "Graduated High School",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Hispanic": {
+            "label": "Hispanic",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Lack_English_Prof": {
+            "label": "Lack Proficiency in English",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Other_Races": {
+            "label": "Other Non-Hispanic Race",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Over 64": {
+            "label": "Over 64 Years Old",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Total": {
+            "label": "Total Population",
+            "unit": MeasureUnit.COUNT
+        },
+        "Under 18": {
+            "label": "Under 18 Years Old",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Urban_Percentage": {
+            "label": "Urbanized Residents",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "White": {
+            "label": "White (non-Hispanic)",
+            "unit": MeasureUnit.PERCENT
+        },
+    },
+    "economy": {
+        "Annual Labor Force Participation Rate": {
+            "label": "Annual Labor Force Participation",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Annual Unemployment Rate": {
+            "label": "Annual Unemployment Rate",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Below Poverty": {
+            "label": "Living Below Poverty",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Gini Coefficient": {
+            "label": "Income Inequality (Gini Coefficient)",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Household Income": {
+            "label": "Household Income ($)",
+            "unit": MeasureUnit.DOLLAR_AMOUNT,
+        },
+        "Insurance Coverage": {
+            "label": "Insured",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Medicaid Enrollment": {
+            "label": "Enrolled in Medicaid",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Monthly Unemployment Rate (Apr)": {
+            "label": "Monthly Unemployment Rate",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Received Public Assistance": {
+            "label": "Received TANF or SNAP Public Assistance",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Uninsured": {
+            "label": "Uninsured",
+            "unit": MeasureUnit.PERCENT
+        },
+    },
+    "environment": {
+        "LILATracts_Vehicle": {
+            "label": "Tracts that are Food Deserts",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "PWS_Violations_Since_2016": {
+            "label": "Public Water System Violations since 2016",
+            "unit": MeasureUnit.PERCENT,
+        },
+    },
+    "housingtrans": {
+        "Crowded Housing": {
+            "label": "Crowded Homes",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Lack Complete Plumbing": {
+            "label": "Homes without Complete Plumbing",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Median Gross Rent": {
+            "label": "Median Gross Rent ($)",
+            "unit": MeasureUnit.DOLLAR_AMOUNT,
+        },
+        "Median Home Value": {
+            "label": "Median Home Value ($)",
+            "unit": MeasureUnit.DOLLAR_AMOUNT,
+        },
+        "Median Monthly Mortgage": {
+            "label": "Median Monthly Mortgage ($)",
+            "unit": MeasureUnit.DOLLAR_AMOUNT,
+        },
+        "Mobile Homes": {
+            "label": "Housing in Mobile Homes",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Multi-Unit Structures": {
+            "label": "Housing in Multi-Unit Structures",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "No Home Broadband": {
+            "label": "Homes without Broadband Internet",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "No Vehicle": {
+            "label": "No Household Vehicle Access",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Owner Occupied Housing": {
+            "label": "Owner-occupied Housing Units",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Rent Burden (40% Income)": {
+            "label": "High Rent Burden",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Single Parent Household": {
+            "label": "Single Parent Homes",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Vacancy Rate": {
+            "label": "Vacant Housing",
+            "unit": MeasureUnit.PERCENT
+        },
+    },
+    "rfandscreening": {
+        "Asthma": {
+            "label": "Diagnosed with Asthma",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Bad_Health": {
+            "label": "Report Fair or Poor Overall Health",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Binge_Drinking": {
+            "label": "Binge Drink",
+            "unit": MeasureUnit.PERCENT
+        },
+        "BMI_Obese": {
+            "label": "Obese (BMI over 30)",
+            "unit": MeasureUnit.PERCENT
+        },
+        "BP_Medicine": {
+            "label": "On Blood Pressure Medication",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Cancer_Prevalence": {
+            "label": "History of Cancer Diagnosis",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "CHD": {
+            "label": "Have Coronary Heart Disease",
+            "unit": MeasureUnit.PERCENT
+        },
+        "COPD": {
+            "label": "Have COPD",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Currently_Smoke": {
+            "label": "Currently Smoke",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Depression": {
+            "label": "Have Depression",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Diabetes_DX": {
+            "label": "Diagnosed with Diabetes",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Had_Stroke": {
+            "label": "Had a Stroke",
+            "unit": MeasureUnit.PERCENT
+        },
+        "High_BP": {
+            "label": "Have High Blood Pressure",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Kidney_Disease": {
+            "label": "Have Chronic Kidney Disease",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Met_Breast_Screen": {
+            "label": "Met Breast Screening Recommendations",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Met_Cervical_Screen": {
+            "label": "Met Cervical Screening Recommendations",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Met_Colon_Screen": {
+            "label": "Met Colorectal Screening Recommendations",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "No_Teeth": {
+            "label": "All Adult Teeth Lost",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Physically_Inactive": {
+            "label": "Physically Inactive",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Poor_Mental": {
+            "label": "Report Frequent Mental Health Distress",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Poor_Physical": {
+            "label": "Report Frequent Physical Health Distress",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Recent_Checkup": {
+            "label": "Had a Medical Checkup in the Last Year",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Recent_Dentist": {
+            "label": "Had a Dental Visit in the Last Year",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Sleep_Debt": {
+            "label": "Sleep < 7 Hours a Night",
+            "unit": MeasureUnit.PERCENT
+        },
+    },
+    "fooddesert": {
+        "LILATracts_Vehicle": {
+            "label": "Tracts that are Food Deserts",
+            "unit": MeasureUnit.PERCENT,
+        },
+    },
+    "disparities": {
+        "Living Below Poverty (Black)": {
+            "label": "Black Population Living Below Poverty",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Uninsured (Black)": {
+            "label": "Black Population without Health Insurance",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Uninsured Children": {
+            "label": "Children without Health Insurance",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Economic Segregation": {
+            "label": "Economic Segregation",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Gender Pay Gap": {
+            "label": "Gender Pay Gap",
+            "unit": MeasureUnit.PERCENT
+        },
+        "Living Below Poverty (Hispanic)": {
+            "label": "Hispanic Population Living Below Poverty",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Uninsured (Hispanic)": {
+            "label": "Hispanic Population without Health Insurance",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Gini Coefficient": {
+            "label": "Income Inequality (Gini Coefficient)",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Racial Economic Segregation": {
+            "label": "Racial Economic Segregation",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Racial Segregation": {
+            "label": "Racial Segregation",
+            "unit": MeasureUnit.PERCENT,
+        },
+        "Lack_English_Prof": {
+            "label": "Lack Proficiency in English",
+            "unit": MeasureUnit.PERCENT,
+        },
+    },
+    "cancerincidence": {
+        "All Site": {
+            "label": "All Cancer Sites",
+            "unit": MeasureUnit.RATE
+        },
+        "Bladder": {
+            "label": "Bladder",
+            "unit": MeasureUnit.RATE
+        },
+        "Brain & ONS": {
+            "label": "Brain & ONS",
+            "unit": MeasureUnit.RATE
+        },
+        "Cervix": {
+            "label": "Cervix",
+            "unit": MeasureUnit.RATE
+        },
+        "Colon & Rectum": {
+            "label": "Colon & Rectum",
+            "unit": MeasureUnit.RATE
+        },
+        "Corpus Uteri & Uterus, NOS": {
+            "label": "Corpus Uteri & Uterus, NOS",
+            "unit": MeasureUnit.RATE,
+        },
+        "Esophagus": {
+            "label": "Esophagus",
+            "unit": MeasureUnit.RATE
+        },
+        "Female Breast": {
+            "label": "Female Breast",
+            "unit": MeasureUnit.RATE
+        },
+        "Kidney & Renal Pelvis": {
+            "label": "Kidney & Renal Pelvis",
+            "unit": MeasureUnit.RATE,
+        },
+        "Leukemia": {
+            "label": "Leukemia",
+            "unit": MeasureUnit.RATE
+        },
+        "Liver & IBD": {
+            "label": "Liver & IBD",
+            "unit": MeasureUnit.RATE
+        },
+        "Lung & Bronchus": {
+            "label": "Lung & Bronchus",
+            "unit": MeasureUnit.RATE
+        },
+        "Melanoma of the Skin": {
+            "label": "Melanoma of the Skin",
+            "unit": MeasureUnit.RATE,
+        },
+        "Non-Hodgkin Lymphoma": {
+            "label": "Non-Hodgkin Lymphoma",
+            "unit": MeasureUnit.RATE,
+        },
+        "Oral Cavity & Pharynx": {
+            "label": "Oral Cavity & Pharynx",
+            "unit": MeasureUnit.RATE,
+        },
+        "Ovary": {
+            "label": "Ovary",
+            "unit": MeasureUnit.RATE
+        },
+        "Pancreas": {
+            "label": "Pancreas",
+            "unit": MeasureUnit.RATE
+        },
+        "Prostate": {
+            "label": "Prostate",
+            "unit": MeasureUnit.RATE
+        },
+        "Stomach": {
+            "label": "Stomach",
+            "unit": MeasureUnit.RATE
+        },
+        "Thyroid": {
+            "label": "Thyroid",
+            "unit": MeasureUnit.RATE
+        },
+    },
+    "cancermortality": {
+        "All Site": {
+            "label": "All Cancer Sites",
+            "unit": MeasureUnit.RATE
+        },
+        "Bladder": {
+            "label": "Bladder",
+            "unit": MeasureUnit.RATE
+        },
+        "Brain & ONS": {
+            "label": "Brain & ONS",
+            "unit": MeasureUnit.RATE
+        },
+        "Cervix": {
+            "label": "Cervix",
+            "unit": MeasureUnit.RATE
+        },
+        "Colon & Rectum": {
+            "label": "Colon & Rectum",
+            "unit": MeasureUnit.RATE
+        },
+        "Corpus Uteri & Uterus, NOS": {
+            "label": "Corpus Uteri & Uterus, NOS",
+            "unit": MeasureUnit.RATE,
+        },
+        "Esophagus": {
+            "label": "Esophagus",
+            "unit": MeasureUnit.RATE
+        },
+        "Female Breast": {
+            "label": "Female Breast",
+            "unit": MeasureUnit.RATE
+        },
+        "Kidney & Renal Pelvis": {
+            "label": "Kidney & Renal Pelvis",
+            "unit": MeasureUnit.RATE,
+        },
+        "Leukemia": {
+            "label": "Leukemia",
+            "unit": MeasureUnit.RATE
+        },
+        "Liver & IBD": {
+            "label": "Liver & IBD",
+            "unit": MeasureUnit.RATE
+        },
+        "Lung & Bronchus": {
+            "label": "Lung & Bronchus",
+            "unit": MeasureUnit.RATE
+        },
+        "Melanoma of the Skin": {
+            "label": "Melanoma of the Skin",
+            "unit": MeasureUnit.RATE,
+        },
+        "Non-Hodgkin Lymphoma": {
+            "label": "Non-Hodgkin Lymphoma",
+            "unit": MeasureUnit.RATE,
+        },
+        "Oral Cavity & Pharynx": {
+            "label": "Oral Cavity & Pharynx",
+            "unit": MeasureUnit.RATE,
+        },
+        "Ovary": {
+            "label": "Ovary",
+            "unit": MeasureUnit.RATE
+        },
+        "Pancreas": {
+            "label": "Pancreas",
+            "unit": MeasureUnit.RATE
+        },
+        "Prostate": {
+            "label": "Prostate",
+            "unit": MeasureUnit.RATE
+        },
+        "Stomach": {
+            "label": "Stomach",
+            "unit": MeasureUnit.RATE
+        },
+        "Thyroid": {
+            "label": "Thyroid",
+            "unit": MeasureUnit.RATE
+        },
+    },
+}
+
+# region "Commentary On Measure Descriptions"
+# -----------------
+# notes on differences from KYCancerNeeds in the above metdata:
+
+# on the KY site, there are many more measures than in the data we have
+# available. above, we only include the ones that are present in the data.
+
+# NOTE: in the KY site, rfandscreening seems to be split between
+#  "Screening & Risk Factors" and "Other Health Factors" but in
+#  the data they're merged into rfandscreening (akak "Screening & Risk
+#  Factors")
+
+# labels from "Screening & Risk Factors" category on the KY site
+# - Met Breast Screening Recommendations
+# - Had Pap Test in Last 3 Years, Age 21-64
+# - Met Colorectal Screening Recommendations
+# - Currently Smoke (adults)
+# - Obese (BMI over 30)
+# - Physical Inactive
+# - Binge Drink
+# - Sleep < 7 Hours a Night
+# - History of Cancer Diagnosis
+
+# labels from "Other Health Factors" category
+# - Report Fair or Poor Overall Health
+# - Report Frequent Physical Health Distress
+# - Report Frequent Mental Health Distress
+# - Have Depression
+# - Diagnosed with Diabetes
+# - Have High Blood Pressure
+# - On Blood Pressure Medication
+# - Have Coronary Heart Disease
+# - Had a Stroke
+# - Have Chronic Kidney Disease
+# - Diagnosed with Asthma
+# - Have COPD
+# - All Adult Teeth Lost
+# - Had a Medical Checkup in the Last Year
+# - Had a Dental Visit in the Last Year
+
+# cancer measure labels, from KY site:
+# * cancer incidence labels:
+#   - All Cancer Sites
+#   - Bladder Cancer
+#   - Brain Cancer
+#   - Cervical Cancer
+#   - Colorectal Cancer
+#   - Esophageal Cancer
+#   - Female Breast Cancer
+#   - Hodgkin Lymphoma
+#   - Kidney Cancer
+#   - Laryngeal Cancer
+#   - Leukemia
+#   - Liver Cancer
+#   - Lung Cancer
+#   - Melanoma
+#   - Myeloma
+#   - Non-Hodgkin Lymphoma
+#   - Oral Cavity and Pharynx Cancer
+#   - Ovarian Cancer
+#   - Pancreatic Cancer
+#   - Prostate Cancer
+#   - Stomach Cancer
+#   - Thyroid Cancer
+#   - Uterine Cancer
+#   - Uterine, NOS Cancer
+# * cancer mortality labels:
+#   - All Cancer Sites
+#   - Bladder Cancer
+#   - Brain Cancer
+#   - Cervical Cancer
+#   - Colorectal Cancer
+#   - Esophageal Cancer
+#   - Female Breast Cancer
+#   - Hodgkin Lymphoma
+#   - Kidney Cancer
+#   - Laryngeal Cancer
+#   - Leukemia
+#   - Liver Cancer
+#   - Lung Cancer
+#   - Melanoma
+#   - Myeloma
+#   - Non-Hodgkin Lymphoma
+#   - Oral Cavity and Pharynx Cancer
+#   - Ovarian Cancer
+#   - Pancreatic Cancer
+#   - Prostate Cancer
+#   - Stomach Cancer
+#   - Thyroid Cancer
+#   - Uterine Cancer
+#   - Uterine, NOS Cancer
+# -----------------
+# endregion
+
+# descriptions of factors, i.e. additional enumerated values associated
+# with each record. for example, cancer stats have race/ethnicity and sex
+# associated with them, and can be filtered by those values.
+# the 'default' field identifies which value is used if the user doesn't
+# supply one when querying.
+# format:
+# {
+#  <model name>: {
+#   <field id>: {
+#     label: <field label>,
+#     default: <default val>,
+#     values: { <value>: <label> }
+#   }, ...
+#  }, ...
+# }
+CIF_FACTOR_DESCRIPTIONS = {
+    "cancerincidence": {
+        "RE": {
+            "label": "Race/Ethnicity",
+            "default": "All",
+            "values": {
+                "All": "All",
+                "Black NH": "Black (non-Hispanic)",
+                "Hispanic": "Hispanic",
+                "White NH": "White (Non-Hispanic)",
+            },
+        },
+        "Sex": {
+            "label": "Sex",
+            "default": "All",
+            "values": {
+                "All": "All",
+                "Female": "Female",
+                "Male": "Male"
+            },
+        },
+    },
+    "cancermortality": {
+        "RE": {
+            "label": "Race/Ethnicity",
+            "default": "All",
+            "values": {
+                "All": "All",
+                "Black NH": "Black (non-Hispanic)",
+                "Hispanic": "Hispanic",
+                "White NH": "White (Non-Hispanic)",
+            },
+        },
+        "Sex": {
+            "label": "Sex",
+            "default": "All",
+            "values": {
+                "All": "All",
+                "Female": "Female",
+                "Male": "Male"
+            },
+        },
+    },
+}

--- a/backend/app/models/cif_meta.py
+++ b/backend/app/models/cif_meta.py
@@ -295,7 +295,7 @@ CIF_MEASURE_DESCRIPTIONS = {
         },
         "Economic Segregation": {
             "label": "Economic Segregation",
-            "unit": MeasureUnit.RATIO,
+            "unit": MeasureUnit.LEAST_MOST,
         },
         "Gender Pay Gap": {
             "label": "Gender Pay Gap",
@@ -315,11 +315,11 @@ CIF_MEASURE_DESCRIPTIONS = {
         },
         "Racial Economic Segregation": {
             "label": "Racial Economic Segregation",
-            "unit": MeasureUnit.RATIO,
+            "unit": MeasureUnit.LEAST_MOST,
         },
         "Racial Segregation": {
             "label": "Racial Segregation",
-            "unit": MeasureUnit.RATIO,
+            "unit": MeasureUnit.LEAST_MOST,
         },
         "Lack_English_Prof": {
             "label": "Lack Proficiency in English",

--- a/backend/app/models/disparity_index.py
+++ b/backend/app/models/disparity_index.py
@@ -9,7 +9,7 @@ Note that since they're all at the county level, we leave out putting
 "county" in the name.
 """
 
-from .base import MeasuresByCounty
+from .base import MeasureUnit, MeasuresByCounty
 
 # ===========================================================================
 # === models from the CDPHE disparity index data
@@ -29,4 +29,25 @@ DISPARITY_INDEX_MODELS = {
         CancerDisparitiesIndex
     ],
     "tract": []
+}
+
+DISPARITY_INDEX_MEASURE_DESCRIPTIONS = {
+    "cancerdisparitiesindex": {
+        "Colorectal Cancer Index": {
+            "label": "Colorectal Cancer Index",
+            "unit": MeasureUnit.RANK,
+        },
+        "Lung Cancer Index": {
+            "label": "Lung Cancer Index",
+            "unit": MeasureUnit.RANK
+        },
+        "Head and Neck Cancer Index": {
+            "label": "Head and Neck Cancer Index",
+            "unit": MeasureUnit.RANK,
+        },
+        "Breast Cancer Index": {
+            "label": "Breast Cancer Index",
+            "unit": MeasureUnit.RANK,
+        },
+    }
 }

--- a/backend/app/routers/statistics.py
+++ b/backend/app/routers/statistics.py
@@ -62,6 +62,7 @@ class FIPSMeasureResponse(BaseModel):
 
 class FactorMetaResponse(BaseModel):
     label : str
+    default : str | None
     values : dict[str, str]
 
 class MeasuresMetaResponse(BaseModel):
@@ -143,6 +144,7 @@ async def get_measures(session: AsyncSession = Depends(get_session)):
                 return {
                     f: {
                         "label": str(fv["label"] or f),
+                        "default": fv.get("default"),
                         "values": {
                             x: fv.get("values", {}).get(x, x) or x
                             for x in factor_results[f].scalars().all()

--- a/backend/app/routers/statistics.py
+++ b/backend/app/routers/statistics.py
@@ -3,6 +3,7 @@ API endpoints that return statistics, e.g. cancer incidence/mortality,
 or sociodemographic measures.
 """
 
+from enum import Enum
 import os
 import csv
 from io import StringIO, BytesIO
@@ -25,6 +26,7 @@ from db import get_session
 
 from settings import LIMIT_TO_STATE
 
+from models.base import MeasureUnit
 from models import (
     STATS_MODELS,
     CANCER_MODELS,
@@ -52,6 +54,7 @@ class FIPSValue(BaseModel):
 class FIPSMeasureResponse(BaseModel):
     min: Optional[float]
     max: Optional[float]
+    unit: Optional[MeasureUnit]
     values: dict[str, FIPSValue]
 
 # provides high-level information about the available categories and measures
@@ -152,7 +155,7 @@ async def get_measures(session: AsyncSession = Depends(get_session)):
                 "label": model.Config.label or simple_model_name,
                 "measures": {
                     x: {
-                        "label": measure_descs.get(x, x) or x,
+                        "label": measure_descs.get(x, {}).get('label') or x,
                         "factors": await get_factors_with_values(model, x)
                     }
                     for x in result.scalars().all()
@@ -281,7 +284,7 @@ for type, family in STATS_MODELS.items():
                 #     description="A set of factor/value pairs on which to filter"
                 # ),
                 filters : Annotated[
-                    str | None, Query(regex="^([^:]+:[^:;]+;)*([^:]+:[^:;]+)$"),
+                    str | None, Query(pattern="^([^:]+:[^:;]+;)*([^:]+:[^:;]+)$"),
                 ] = None,
                 session: AsyncSession = Depends(get_session)
             ):
@@ -376,9 +379,19 @@ for type, family in STATS_MODELS.items():
                 else:
                     values = {x["FIPS"]: {"value": x["value"]} for x in objects}
 
+                # determine the unit of measurement for the measure from the metadata
+                # (if available)
+                unit = (
+                    MEASURE_DESCRIPTIONS
+                        .get(simple_model_name, {})
+                        .get(measure, {})
+                        .get("unit", None)
+                )
+
                 return FIPSMeasureResponse(
                     min=stats[0],
                     max=stats[1],
+                    unit=unit,
                     values=values
                 )
 
@@ -397,17 +410,23 @@ for type, family in STATS_MODELS.items():
                 session: AsyncSession = Depends(get_session)
             ):
                 # get human labels for measures within this model, if available
-                model_measure_labels = MEASURE_DESCRIPTIONS.get(simple_model_name, {})
+                model_measure_meta = MEASURE_DESCRIPTIONS.get(simple_model_name, {})
                 # get factors associated with this model, if any
                 # (they'll be added as columns to the output)
                 factor_labels = FACTOR_DESCRIPTIONS.get(simple_model_name, None)
 
                 def model_to_fields(x, factor_labels):
+                    model_measure_label = (
+                        model_measure_meta
+                            .get(x["measure"], {})
+                            .get("label") or x["measure"]
+                    )
+                    
                     fields = [
                         x["GEOID"],
                         x["County"],
                         x["State"],
-                        get_or_key(model_measure_labels, x["measure"]),
+                        model_measure_label,
                         x["value"],
                     ]
 
@@ -508,7 +527,7 @@ async def download_all(
                 simple_model_name = slug_modelname_sans_type(model, type)
 
                 # get human labels for measures within this model, if available
-                model_measure_labels = MEASURE_DESCRIPTIONS.get(simple_model_name, {})
+                model_measure_meta = MEASURE_DESCRIPTIONS.get(simple_model_name, {})
 
                 # retrieve the measures for the model, depending on what type of model it is
                 if model in CANCER_MODELS:
@@ -544,7 +563,8 @@ async def download_all(
 
                         # produce a human-readable name for the measure, if available,
                         # from the MEASURE_DESCRIPTIONS entry for this model
-                        final_name = f"{get_or_key(model_measure_labels, measure)}.csv"
+                        model_measure_label = model_measure_meta.get(measure, {}).get("label") or measure
+                        final_name = f"{model_measure_label}.csv"
                         
                         # produce a complete path consisting of the type, the
                         # name of the model (aka measure category), and the

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from fastapi.testclient import TestClient
+
+import sys
+sys.path.append("/app")
+
+from main import app
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c

--- a/backend/app/tests/test_scp_measuremapper.py
+++ b/backend/app/tests/test_scp_measuremapper.py
@@ -1,19 +1,48 @@
+import pytest
+
 import sys
 sys.path.append("/app")
 
 from models.base import MeasureUnit
 from models.scp import SCP_MEASURE_DESCRIPTIONS
 
+from tools.collections import MeasureMapper
+
 def test_scp_mapped_measures():
-    from app.tools.collections import MeasureMapper
-
+    """
+    Spot-check the MeasureMapper objects in SCP_MEASURE_DESCRIPTIONS
+    and ensure we're getting the right units back, both via __getitem__()
+    and via get().
+    """
     for model, mapper in SCP_MEASURE_DESCRIPTIONS.items():
-        # ensure it's dict-like
-        assert isinstance(mapper, dict)
-
         # ensure that trends give us ordinal values (e.g., falling, stable, rising)
         # and that everything else gives us rates (i.e., incindence, mortality rates per 100k)
         expected_unit = MeasureUnit.ORDINAL if "trend" in model else MeasureUnit.RATE
+
+        assert mapper["All Cancer Sites"]["unit"] is not None
         assert mapper["All Cancer Sites"]["unit"] == expected_unit
 
+        assert mapper["All Cancer Sites"].get("unit") is not None
+        assert mapper["All Cancer Sites"].get("unit") == expected_unit
+
     
+def test_measuremapper_immutable():
+    """
+    Ensure that we can't set items on a MeasureMapper object.
+    """
+    mapper = MeasureMapper(MeasureUnit.RATE)
+
+    with pytest.raises(TypeError):
+        mapper["foo"] = "bar"
+    
+    with pytest.raises(AttributeError):
+        mapper.set("foo", "bar")
+
+def test_measuremapper_stringification():
+    """
+    Test str/repr methods on MeasureMapper.
+    """
+    mapper = MeasureMapper(MeasureUnit.RATE)
+
+    assert str(mapper) == "MeasureMapper(default_unit=MeasureUnit.RATE)"
+    assert repr(mapper) == "MeasureMapper(default_unit=MeasureUnit.RATE)"

--- a/backend/app/tests/test_scp_measuremapper.py
+++ b/backend/app/tests/test_scp_measuremapper.py
@@ -1,0 +1,19 @@
+import sys
+sys.path.append("/app")
+
+from models.base import MeasureUnit
+from models.scp import SCP_MEASURE_DESCRIPTIONS
+
+def test_scp_mapped_measures():
+    from app.tools.collections import MeasureMapper
+
+    for model, mapper in SCP_MEASURE_DESCRIPTIONS.items():
+        # ensure it's dict-like
+        assert isinstance(mapper, dict)
+
+        # ensure that trends give us ordinal values (e.g., falling, stable, rising)
+        # and that everything else gives us rates (i.e., incindence, mortality rates per 100k)
+        expected_unit = MeasureUnit.ORDINAL if "trend" in model else MeasureUnit.RATE
+        assert mapper["All Cancer Sites"]["unit"] == expected_unit
+
+    

--- a/backend/app/tests/test_units_in_response.py
+++ b/backend/app/tests/test_units_in_response.py
@@ -1,0 +1,27 @@
+import pytest
+
+from urllib.parse import quote_plus
+
+import sys
+sys.path.append("/app")
+
+from models.base import STATS_MODELS, MEASURE_DESCRIPTIONS
+from tools.strings import slug_modelname_sans_type
+
+pytestmark = pytest.mark.asyncio
+
+async def test_unit_in_response(client):
+    for type in STATS_MODELS:
+        for model in STATS_MODELS[type]:
+            simple_model_name = slug_modelname_sans_type(model, type)
+
+            for measure, meta in MEASURE_DESCRIPTIONS[simple_model_name].items():
+                encoded_measure = quote_plus(measure)
+                path = f"/stats/{type}/{simple_model_name}/fips-value?measure={encoded_measure}"
+                response = client.get(path)
+
+                assert response.status_code == 200, path
+                data = response.json()
+
+                assert 'unit' in data
+                assert data['unit'] is not None and data['unit'] == meta['unit'].value

--- a/backend/app/tools/collections.py
+++ b/backend/app/tools/collections.py
@@ -3,9 +3,11 @@ Utilities for producing things that look like collections,
 but generate the values on the fly.
 """
 
+from collections.abc import Mapping
+
 from models.base import MeasureUnit
 
-class MeasureMapper(dict):
+class MeasureMapper(Mapping):
     """
     A dict-like that, given a key, produces a result like { label: <key>, unit:
     <default_unit> }
@@ -14,15 +16,32 @@ class MeasureMapper(dict):
     its label are the same, and the unit is shared across lots of different
     measures.
     """
-    
-    def __init__(self, default_unit:MeasureUnit):
+
+    def __init__(self, default_unit: MeasureUnit):
         self.default_unit = default_unit
 
     def __getitem__(self, key):
-        return {
-            "label": key,
-            "unit": self.default_unit,
-        }
+        return {"label": key, "unit": self.default_unit}
+    
+    def get(self, key, default=None):
+        return {"label": key, "unit": self.default_unit}
+    
+    def __len__(self):
+        """
+        Returns 0, since the object has virtual keys and thus
+        there's nothing to count.
+        """
+        return 0
 
-    def __setitem__(self, *args, **kwargs) -> None:
-        raise NotImplementedError("MeasureMapper is read-only")
+    def __iter__(self):
+        """
+        Returns an empty iterator, since the object has virtual keys and thus
+        there's nothing to iterate over.
+        """
+        return iter([])
+    
+    def __repr__(self):
+        return f"MeasureMapper(default_unit={self.default_unit})"
+    
+    def __str__(self):
+        return repr(self)

--- a/backend/app/tools/collections.py
+++ b/backend/app/tools/collections.py
@@ -1,0 +1,28 @@
+"""
+Utilities for producing things that look like collections,
+but generate the values on the fly.
+"""
+
+from models.base import MeasureUnit
+
+class MeasureMapper(dict):
+    """
+    A dict-like that, given a key, produces a result like { label: <key>, unit:
+    <default_unit> }
+
+    This is useful for many of our stats models where the key for a measure and
+    its label are the same, and the unit is shared across lots of different
+    measures.
+    """
+    
+    def __init__(self, default_unit:MeasureUnit):
+        self.default_unit = default_unit
+
+    def __getitem__(self, key):
+        return {
+            "label": key,
+            "unit": self.default_unit,
+        }
+
+    def __setitem__(self, *args, **kwargs) -> None:
+        raise NotImplementedError("MeasureMapper is read-only")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ GeoAlchemy2==0.14.1
 geojson-pydantic==0.6.3
 greenlet==2.0.2
 h11==0.14.0
+httpx==0.27.0
 idna==3.4
 Mako==1.2.4
 MarkupSafe==2.1.3

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -143,6 +143,17 @@ export async function getFacets() {
 
 export type Facets = Awaited<ReturnType<typeof getFacets>>;
 
+/** value type/format */
+export type Unit =
+  | "percent"
+  | "count"
+  | "rate"
+  | "dollar_amount"
+  | "rank"
+  | "ordinal"
+  | "ratio"
+  | null;
+
 /** response from values api endpoint */
 type _Values = {
   /** range of values for specified measure */
@@ -150,6 +161,7 @@ type _Values = {
   min: number;
   /** map of feature id to measure value */
   values: { [key: string]: { value: number; aac?: number | null } };
+  unit: Unit;
 };
 
 /** get values data */
@@ -180,6 +192,7 @@ export async function getValues(
     mean: d3.mean(values) || 0,
     median: d3.median(values) || 0,
     values: data.values,
+    unit: data.unit,
   };
 
   /** if missing data, return empty */
@@ -187,7 +200,7 @@ export async function getValues(
 
   /** define explicit scale for certain data */
   let explicitScale: ExplicitScale;
-  if (category.includes("trend"))
+  if (data.unit === "ordinal")
     explicitScale = { 1: "Falling", 2: "Stable", 3: "Rising" };
 
   return { ...stats, explicitScale };

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -93,6 +93,7 @@ type _Facets = {
             factors?: {
               [key: string]: {
                 label: string;
+                default: string;
                 values: { [key: string]: string };
               };
             };
@@ -112,6 +113,7 @@ export type Facet = {
     factors?: {
       [key: string]: {
         label: string;
+        default: string;
         values: { [key: string]: string };
       };
     };

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -153,7 +153,7 @@ export type Unit =
   | "dollar_amount"
   | "rank"
   | "ordinal"
-  | "ratio"
+  | "least_most"
   | null;
 
 /** response from values api endpoint */

--- a/frontend/src/pages/home/SectionMap.vue
+++ b/frontend/src/pages/home/SectionMap.vue
@@ -323,6 +323,7 @@
         :values="values?.values"
         :min="manualMinMax ? manualMin : values?.min"
         :max="manualMinMax ? manualMax : values?.max"
+        :unit="values?.unit"
         :show-legends="showLegends"
         :background-opacity="backgroundOpacity"
         :geometry-opacity="geometryOpacity"
@@ -367,7 +368,9 @@
         <template v-if="showExtras && values" #bottom-left>
           <div class="mini-table">
             <template v-for="(stat, index) in stats" :key="index">
-              <span>{{ stat.key }}</span>
+              <span v-tooltip="startCase(values.unit ?? '')">
+                {{ stat.key }}
+              </span>
               <span v-tooltip="stat.full">
                 {{ stat.compact }}
               </span>
@@ -461,7 +464,7 @@ import {
   stringParam,
   useUrlParam,
 } from "@/util/composables";
-import { formatValue, isPercent } from "@/util/math";
+import { formatValue } from "@/util/math";
 import { sleep } from "@/util/misc";
 
 type Props = {
@@ -474,8 +477,8 @@ const stats = computed(() =>
   values.value
     ? (["min", "max", "mean", "median"] as const).map((key) => ({
         key: startCase(key),
-        full: formatValue(values.value![key], percent.value, false),
-        compact: formatValue(values.value![key], percent.value),
+        full: formatValue(values.value![key], values.value!.unit),
+        compact: formatValue(values.value![key], values.value!.unit, true),
       }))
     : [],
 );
@@ -724,11 +727,6 @@ watch(
   [selectedLevel, selectedCategory, selectedMeasure, selectedFactors],
   loadValues,
   { deep: true, immediate: true },
-);
-
-/** is measure a percent */
-const percent = computed(() =>
-  isPercent(values.value?.min || 0, values.value?.max || 1),
 );
 
 /** turn facet into list of select box options */

--- a/frontend/src/pages/home/SectionMap.vue
+++ b/frontend/src/pages/home/SectionMap.vue
@@ -689,13 +689,16 @@ watch(
 
     /** for each factor */
     for (const [key, value] of Object.entries(factors.value)) {
+      /** default fallback option */
+      const fallback =
+        value.default in value.values
+          ? /** explicitly defined default */
+            value.default
+          : /** first option */
+            Object.entries(value.values || {})[0]?.[0] || "";
+
       /** ref 2-way synced with url */
-      const factor = useUrlParam(
-        key,
-        stringParam,
-        /** default selected */
-        value.values["All"] ? "All" : Object.keys(value.values)[0] || "",
-      );
+      const factor = useUrlParam(key, stringParam, fallback);
       /** hook up url reactive with selected factor */
       selectedFactors.value[key] = factor;
 
@@ -706,13 +709,11 @@ watch(
           factor,
           () => {
             /** get non-stale factor options */
-            const options = factors.value[key]?.values || {};
+            const newValue = factors.value[key];
             /** if value isn't valid anymore */
-            if (!(factor.value in options))
+            if (!(factor.value in (newValue?.values || {})))
               /** fall back */
-              factor.value = options["All"]
-                ? "All"
-                : Object.keys(options)[0] || "";
+              factor.value = fallback;
           },
           { immediate: true },
         ),

--- a/frontend/src/util/math.ts
+++ b/frontend/src/util/math.ts
@@ -1,30 +1,41 @@
+import type { Unit } from "@/api/index";
+
 /** format map data value */
 export function formatValue(
-  value: number,
-  percent = true,
-  compact = true,
+  value: number | string,
+  unit?: Unit,
+  compact = false,
 ): string {
-  if (percent)
-    return (
-      (value * 100).toLocaleString(undefined, {
-        maximumSignificantDigits: compact ? 3 : 5,
-      }) + "%"
-    );
-  else
-    return value.toLocaleString(
-      undefined,
-      compact
-        ? {
-            notation: "compact",
-            maximumSignificantDigits: 3,
-          }
-        : undefined,
-    );
-}
-
-/** check if min/max is within small range and should be treated as percent */
-export function isPercent(min: number, max: number) {
-  return min >= 0 && max <= 1;
+  if (typeof value === "string") return value;
+  const format: Intl.NumberFormatOptions = {};
+  let suffix = "";
+  switch (unit) {
+    case "percent":
+      value *= 100;
+      format.maximumFractionDigits = compact ? 1 : 2;
+      suffix = "%";
+      break;
+    case "count":
+      format.notation = compact ? "compact" : "standard";
+      break;
+    case "rate":
+      format.maximumSignificantDigits = compact ? 3 : 5;
+      break;
+    case "dollar_amount":
+      format.notation = compact ? "compact" : "standard";
+      format.style = "currency";
+      format.currency = "USD";
+      break;
+    case "rank":
+      format.maximumSignificantDigits = compact ? 3 : 5;
+      break;
+    case "ordinal":
+      break;
+    case "ratio":
+      format.maximumFractionDigits = compact ? 2 : 5;
+      break;
+  }
+  return value.toLocaleString(undefined, format) + suffix;
 }
 
 /**

--- a/frontend/src/util/math.ts
+++ b/frontend/src/util/math.ts
@@ -31,7 +31,7 @@ export function formatValue(
       break;
     case "ordinal":
       break;
-    case "ratio":
+    case "least_most":
       format.maximumFractionDigits = compact ? 2 : 5;
       break;
   }


### PR DESCRIPTION
This PR alters the `fips-value` endpoint to include a field named `unit`, which is either `null` or is one of the following string values:

- **"percent"**: a percentage; the datasets we use encode these as floats between 0 and 1, inclusive
- **"count"**: a raw count, represented as an integer, e.g. number of cases
- **"rate"**: a rate of occurrence, represented as a float and typically normalized by population
- **"dollar_amount"**: raw dollar amount, e.g. income
- **"rank"**: a position in a ranking, e.g. for the cancer disparities index ranking of CO counties
- **"ordinal"**: a discrete value that can be ordered, e.g. "rising" (1), "falling" (2), "stable" (3)
- **"categorical"**: a discrete value that *can't* be ordered, e.g. "white", "black", "hispanic"
- **"ratio"**: range from -1 to +1, where -1 is "least affected" and +1 is "most affected"

Some of these units aren't currently in use, e.g. "categorical", and I suspect many of them can be handled in the same way in the frontend.

The PR includes some simple tests that the `unit` field is included in the `fips-value` response and that it matches what's defined in the backend metadata.

The PR also includes a helper class, `MeasureMapper`, a dict-like that when queried for a key produces a dict of the form `{label: <key>, unit: <default_unit>}` for measures where the ID and the label are the same, and all the measures have the same unit. A test is included for it as well.
