### PR TITLE
Automated deployment to backend VM

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,0 +1,32 @@
+name: Deploy ECCO to VM
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy_prod:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - uses: 'actions/checkout@v4'
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}'
+
+      - id: 'compute-ssh'
+        uses: 'google-github-actions/ssh-compute@v1'
+        with:
+          instance_name: 'ecco'
+          zone: 'us-central1-a'
+          user: 'ecco-deployer'
+          ssh_private_key: '${{ secrets.GCP_SSH_PRIVATE_KEY }}'
+          # command: 'cd /var/projects/ecco && git pull && ./run_stack.sh prod'
+          command: 'touch ~/i_was_here'
+  
+      - id: 'test'
+        run: |-
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -16,15 +16,28 @@ jobs:
         with:
           credentials_json: '${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}'
 
+      # - name: Set up Cloud SDK
+      #   uses: 'google-github-actions/setup-gcloud@v2'
+      #   with:
+      #     version: '>= 363.0.0'
+
+      # - id: 'compute-ssh'
+      #   uses: 'google-github-actions/ssh-compute@v1'
+      #   with:
+      #     instance_name: 'ecco'
+      #     zone: 'us-central1-a'
+      #     user: 'ecco-deployer'
+      #     ssh_private_key: '${{ secrets.GCP_SSH_PRIVATE_KEY }}'
+      #     # command: 'cd /var/projects/ecco && git pull && ./run_stack.sh prod'
+      #     command: 'touch ~/i_was_here'
+
       - id: 'compute-ssh'
-        uses: 'google-github-actions/ssh-compute@v1'
-        with:
-          instance_name: 'ecco'
-          zone: 'us-central1-a'
-          user: 'ecco-deployer'
-          ssh_private_key: '${{ secrets.GCP_SSH_PRIVATE_KEY }}'
-          # command: 'cd /var/projects/ecco && git pull && ./run_stack.sh prod'
-          command: 'touch ~/i_was_here'
+        run: |-
+          echo -e "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > /tmp/ssh_key
+          # echo -e "${{ secrets.GCP_SSH_PUBLIC_KEY }}" > /tmp/ssh_key.pub
+          chmod 0600 /tmp/ssh_key*
+          ssh -o StrictHostKeyChecking=accept-new -i /tmp/ssh_key ecco-deployer@api.coe-ecco.org -- 'touch ~/i_was_here'
+          rm /tmp/ssh_key
   
       - id: 'test'
         run: |-

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -11,32 +11,18 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
 
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          credentials_json: '${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}'
-
-      # - name: Set up Cloud SDK
-      #   uses: 'google-github-actions/setup-gcloud@v2'
-      #   with:
-      #     version: '>= 363.0.0'
-
-      # - id: 'compute-ssh'
-      #   uses: 'google-github-actions/ssh-compute@v1'
-      #   with:
-      #     instance_name: 'ecco'
-      #     zone: 'us-central1-a'
-      #     user: 'ecco-deployer'
-      #     ssh_private_key: '${{ secrets.GCP_SSH_PRIVATE_KEY }}'
-      #     # command: 'cd /var/projects/ecco && git pull && ./run_stack.sh prod'
-      #     command: 'touch ~/i_was_here'
-
       - id: 'compute-ssh'
         run: |-
           echo -e "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > /tmp/ssh_key
-          # echo -e "${{ secrets.GCP_SSH_PUBLIC_KEY }}" > /tmp/ssh_key.pub
-          chmod 0600 /tmp/ssh_key*
-          ssh -o StrictHostKeyChecking=accept-new -i /tmp/ssh_key ecco-deployer@api.coe-ecco.org -- 'touch ~/i_was_here'
+          chmod 0600 /tmp/ssh_key
+          ssh -t -o StrictHostKeyChecking=accept-new -i /tmp/ssh_key ecco-deployer@api.coe-ecco.org \
+            -- /bin/bash -i -s << "EOF"
+            cd /var/projects/ecco && \
+            echo $PWD && \
+            git pull && ( echo "$( git rev-parse HEAD ) - $( date )" ) >> deploys.txt && \
+            ./run_stack.sh prod && \
+            exit $( docker container wait ecco-frontend-1 )
+          EOF
           rm /tmp/ssh_key
   
       - id: 'test'

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,5 +1,7 @@
 name: Deploy ECCO to VM
+
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -11,7 +13,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
 
-      - id: 'compute-ssh'
+      - name: SSH into VM and deploy
         run: |-
           echo -e "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > /tmp/ssh_key
           chmod 0600 /tmp/ssh_key
@@ -25,7 +27,5 @@ jobs:
           EOF
           rm /tmp/ssh_key
   
-      - id: 'test'
-        run: |-
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+      - if: runner.debug == '1'
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
 
+      - if: runner.debug == '1'
+        uses: mxschmitt/action-tmate@v3
+
       - name: SSH into VM and deploy
         run: |-
           echo -e "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > /tmp/ssh_key
@@ -27,5 +30,3 @@ jobs:
           EOF
           rm /tmp/ssh_key
   
-      - if: runner.debug == '1'
-        uses: mxschmitt/action-tmate@v3

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 
 # project-specific ignores
 node_modules
+
+# ignores the deploys.txt log on the server, so it won't make the working dir dirty when it's auto-updated
+/deploys.txt


### PR DESCRIPTION
This PR introduces a new GitHub worflow, `deploy-prod.yaml`, that on a merge into `main` does the following:

1. SSHes into the production VM `api.coe-ecco.org` as `ecco-deployer`; the private SSH key is retrieved from the GitHub repo's secrets
2. Enters the deployment folder, `/var/projects/ecco`, on the VM
3. Pulls the latest changes to `main`
4. Appends the current commit hash and system date to `deploys.txt`
5. Launches `./run_stack.sh prod`, which rebuilds images and launches the production version of the stack
6. Waits on the frontend container to finish building the site, then exits with its exit status

I've had trouble getting this to work with [act](https://github.com/nektos/act); sometimes it works, sometimes it fails inexplicably. That's not much of a surprise for `act`, though; it's often flakey, even if the workflow would work when deployed. I am planning to continue to resolve the issues with `act` as it would be a nice way to test workflows prior to merging, but it's not a big priority IMHO. I'm hoping to debug this workflow, if necessary, on GitHub itself.