### PR TITLE
Fixes the by-county endpoint, other testing + module refactors

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,18 +1,40 @@
+from contextlib import contextmanager
 import os
 
-from typing import AsyncGenerator
-
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.orm import sessionmaker
-from sqlmodel import SQLModel
+from typing import AsyncGenerator, Generator
 
 from settings import DATABASE_URL
 
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.pool import NullPool
+
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
 DB_ECHO_USAGE = os.environ.get("DB_ECHO_USAGE", False)
 
-engine = create_async_engine(DATABASE_URL, echo=DB_ECHO_USAGE)
+# we disable pooling via poolclass=NullPool to prevent tests from crashing with
+# 'attached to a different loop', even though it appears to work fine in actual
+# use.
+# see here for more information:
+# https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html#using-multiple-asyncio-event-loops
+# FIXME: see if disabling pooling impacts performance, and perhaps only
+#  disable it when running tests.
+engine = create_async_engine(
+    DATABASE_URL, echo=DB_ECHO_USAGE,
+    poolclass=NullPool,
+)
 
 async def init_db():
+    """
+    Creates tables in the database via SQLModel's metadata.
+
+    Currently unused, as we're using Alembic for schema migrations,
+    including the initial table creation.
+    """
     async with engine.begin() as conn:
         # await conn.run_sync(SQLModel.metadata.drop_all)
         await conn.run_sync(SQLModel.metadata.create_all)
@@ -23,4 +45,20 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
         engine, class_=AsyncSession, expire_on_commit=False
     )
     async with async_session() as session:
+        yield session
+
+sync_engine = create_engine(
+    DATABASE_URL.replace("asyncpg", "psycopg2"), echo=DB_ECHO_USAGE
+)
+
+@contextmanager
+def get_sync_session() -> Generator[Session, None, None]:
+    """
+    Gets a synchronous db session, for use when we don't
+    have an async context available.
+    """
+    sync_session = sessionmaker(
+        sync_engine, class_=Session, expire_on_commit=False
+    )
+    with sync_session() as session:
         yield session

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -15,13 +15,6 @@ from sqlmodel import Field, SQLModel
 class BaseStatsModel(SQLModel):
     id: Optional[int] = Field(default=None, nullable=False, primary_key=True)
 
-class MeasuresByCounty(BaseStatsModel):
-    FIPS : str = Field(index=True)
-    County : str = Field(index=True)
-    State : str = Field(index=True, foreign_key="us_state.name")
-    measure : str = Field(index=True)
-    value : float = Field(nullable=True)
-
     @classmethod
     def get_factors(cls):
         """
@@ -30,6 +23,13 @@ class MeasuresByCounty(BaseStatsModel):
         This is a placeholder method that should be overridden by child models.
         """
         return ()
+
+class MeasuresByCounty(BaseStatsModel):
+    FIPS : str = Field(index=True)
+    County : str = Field(index=True)
+    State : str = Field(index=True, foreign_key="us_state.name")
+    measure : str = Field(index=True)
+    value : float = Field(nullable=True)
 
 class CancerStatsByCounty(BaseStatsModel):
     # NOTE: the 'measure' and 'value' columns are named 'Site' and 'AAR' in the

--- a/backend/app/models/scp.py
+++ b/backend/app/models/scp.py
@@ -117,10 +117,24 @@ SCP_TRENDS_MODELS = {
 # might consider switching this object to an accessor that returns
 # the verbatim measure name and MeasureUnit.RATE for all measures
 SCP_MEASURE_DESCRIPTIONS = {
-    "scpincidence": MeasureMapper(MeasureUnit.RATE),
-    "scpdeaths": MeasureMapper(MeasureUnit.RATE),
-    "scpincidencetrend": MeasureMapper(MeasureUnit.ORDINAL, extras={"order": ["falling", "stable", "rising"]}),
-    "scpdeathstrend": MeasureMapper(MeasureUnit.ORDINAL, extras={"order": ["falling", "stable", "rising"]}),
+    "scpincidence": MeasureMapper(
+        MeasureUnit.RATE,
+        model=SCPIncidenceCounty, measure_column='Site'
+    ),
+    "scpdeaths": MeasureMapper(
+        MeasureUnit.RATE,
+        model=SCPDeathsCounty, measure_column='Site'
+    ),
+    "scpincidencetrend": MeasureMapper(
+        MeasureUnit.ORDINAL,
+        model=SCPIncidenceTrendCounty, measure_column='Site',
+        extras={"order": ["falling", "stable", "rising"]}
+    ),
+    "scpdeathstrend": MeasureMapper(
+        MeasureUnit.ORDINAL,
+        model=SCPDeathsTrendCounty, measure_column='Site',
+        extras={"order": ["falling", "stable", "rising"]}
+    ),
 }
 
 # descriptions of factors, i.e. additional enumerated values associated

--- a/backend/app/tests/README.md
+++ b/backend/app/tests/README.md
@@ -1,0 +1,11 @@
+# ECCO Backend Tests
+
+This folder contains tests for the ECCO backend. The tests are written using the
+[pytest](https://docs.pytest.org/en/stable/) framework.
+
+The tests are organized into the following subfolders:
+- `metadata_integrity`: Tests that our metadata agrees with our sources (e.g.,
+  CancerInFocus, State Cancer Profiles data releases as they come out)
+- `helpers`: Tests for small helper functions in the backend
+- `integration`: Tests that require actual stack services, e.g. a running,
+  populated database

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,13 +1,13 @@
-import pytest
+import sys
 
+import pytest_asyncio
 from fastapi.testclient import TestClient
 
-import sys
 sys.path.append("/app")
 
 from main import app
 
-@pytest.fixture
-def client():
+@pytest_asyncio.fixture()
+async def client():
     with TestClient(app) as c:
         yield c

--- a/backend/app/tests/helpers/test_measuremapper.py
+++ b/backend/app/tests/helpers/test_measuremapper.py
@@ -1,7 +1,7 @@
 import pytest
 
 import sys
-sys.path.append("/app")
+sys.path.append("/app/src")
 
 from models.base import MeasureUnit
 from models.scp import SCP_MEASURE_DESCRIPTIONS

--- a/backend/app/tests/integration/test_fips_vs_county_values.py
+++ b/backend/app/tests/integration/test_fips_vs_county_values.py
@@ -1,0 +1,76 @@
+import pytest
+
+from urllib.parse import quote_plus
+
+import sys
+sys.path.append("/app/src")
+
+from models.base import STATS_MODELS, MEASURE_DESCRIPTIONS
+from tools.strings import slug_modelname_sans_type
+
+
+@pytest.mark.asyncio(loop_scope='function')
+async def test_fips_vs_bycounty(event_loop, client):
+    """
+    Test that the values we get from the fips-value endpoint for a county
+    match what the by-county endpoint is returning.
+    """
+
+    # we're just testing counties here, since we don't have a by-tract endpoint
+    type = "county"
+
+    # remember by-county data so we don't have to re-query it
+    by_county_data = {}
+
+    for model in STATS_MODELS["county"]:
+        simple_model_name = slug_modelname_sans_type(model, type)
+
+        for measure, meta in MEASURE_DESCRIPTIONS[simple_model_name].items():
+            # skip tract-only measures when testing counties
+            if type == "county" and meta.get("tract_only", False):
+                continue
+
+            encoded_measure = quote_plus(measure)
+            path = f"/stats/{type}/{simple_model_name}/fips-value?measure={encoded_measure}"
+            response = client.get(path)
+
+            assert response.status_code == 200, path
+            summary_fips_data = response.json()
+
+            # first check that there's anything to compare
+            # assert 'values' in summary_fips_data and len(summary_fips_data['values']) > 0, path
+
+            # for each county FIPS in the fips-value response, query the
+            # by-county endpoint and compare the returned values
+            for fips in summary_fips_data['values'].keys():
+                # after this runs, 'county_data' will either have been populated
+                # via a query or populated from the cache
+                if fips not in by_county_data:
+                    path = f"/stats/by-county/{fips}"
+                    response = client.get(path)
+                    assert response.status_code == 200, path
+                    county_data = response.json()
+                    by_county_data[fips] = county_data
+                else:
+                    county_data = by_county_data[fips]
+
+                # retrieve the fips-value data for the current county
+                fips_set_value = summary_fips_data["values"][fips]["value"]
+                # retrieve by-county data for the current measure
+                try:
+                    county_measure_value = county_data["categories"][simple_model_name]["measures"][measure]["value"]
+                except KeyError:
+                    # raise Exception(f"Missing {simple_model_name}:{measure} in by-county data (FIPS: {fips})")
+                    
+                    # we're skipping b/c some counties just don't have certain
+                    # measures for example, 08057 (jackson county) has no
+                    # `trend` values for `scpdeaths`, and since we require trend
+                    # != '' for the by-county endpoint, we don't get anything
+                    # back and the dict ref above would fail.
+                    print(f"Skipping {simple_model_name}:{measure} in by-county data (FIPS: {fips}) since it doesn't exist")
+                    continue
+
+                # print(f"Comparing for FIPS {fips} {simple_model_name}/{measure}: county value {county_measure_value} vs. fips-value {fips_set_value}")
+
+                # ensure that it matches the fips-value data
+                assert county_measure_value == fips_set_value, f"Mismatch for FIPS {fips} {simple_model_name}/{measure}: county value {county_measure_value} != fips-value {fips_set_value}"

--- a/backend/app/tests/integration/test_measures_populated.py
+++ b/backend/app/tests/integration/test_measures_populated.py
@@ -1,0 +1,128 @@
+import pytest
+
+from urllib.parse import quote_plus
+
+import sys
+
+from models.scp import SCP_CANCER_MODELS
+from tools.collections import MeasureMapper
+sys.path.append("/app/src")
+
+from models.base import STATS_MODELS, MEASURE_DESCRIPTIONS, MeasureUnit
+from tools.strings import slug_modelname_sans_type
+
+
+@pytest.mark.asyncio
+async def test_measures_populated(client):
+    """
+    For each model in MEASURE_DESCRIPTIONS, check that the measure is populated,
+    i.e. that it has more than zero rows.
+    """
+
+    # first, pull the 'measures' endpoint to get metadata about the measures
+    # that we'll use when we issue the queries
+    response = client.get("/stats/measures")
+    assert response.status_code == 200
+    measures = response.json()
+
+    for type in STATS_MODELS:
+        for model in STATS_MODELS[type]:
+            simple_model_name = slug_modelname_sans_type(model, type)
+
+            for measure, meta in MEASURE_DESCRIPTIONS[simple_model_name].items():
+                # retrieve metadata about the factors for the given model+type
+                factor_meta = (
+                    measures[type]["categories"]
+                        .get(simple_model_name, {})
+                        .get("measures", {})
+                        .get(measure, {})
+                        .get("factors")
+                )
+
+                # skip county-only measures when testing tracts
+                if type == "tract" and meta.get("county_only", False):
+                    continue
+                # skip tract-only measures when testing counties
+                if type == "county" and meta.get("tract_only", False):
+                    continue
+
+                # ==============================================================================================
+                # === resolve factor values that will produce data
+                # ==============================================================================================
+
+                # the following figures out what factors are populated for
+                # measures that have factors and use those in the query. (for
+                # example, Site="Breast (Female)" will produce no results when
+                # querying without specifying the sex, since it will default to
+                # sex="All")
+
+                # if there are factors for the current model, query for values
+                # of those factors that we know will produce results, preferring
+                # the factor's default value if multiple options exist.
+                # if that's not possible (e.g., if there's no data at all), just
+                # query for the default values.
+                factors = None
+
+                print(model.get_factors())
+                print(str(factor_meta))
+
+                if len(model.get_factors()) > 0 and factor_meta is not None:
+                    # get populated value options for each factor
+                    factor_values = {}
+
+                    for factor_field in model.get_factors():
+                        # factor field names are in the form of "model.field"
+                        factor = str(factor_field).split(".")[-1]
+                        factor_opts = list(factor_meta[factor].get("values", {}).keys())
+
+                        # use the default if it's populated, otherwise use the first value
+                        factor_values[factor] =  (
+                            factor_meta[factor]["default"]
+                            if factor_meta[factor]["default"] in factor_opts or len(factor_opts) == 0 else
+                            factor_opts[0]
+                        )
+
+                    # construct a querystring arg for the chosen factor values
+                    factors = [
+                        f"{factor}:{factor_values[factor]}"
+                        for factor in factor_values
+                    ]
+
+                # ==============================================================================================
+                # === perform query for the measure
+                # ==============================================================================================
+
+                encoded_measure = quote_plus(measure)
+                path = f"/stats/{type}/{simple_model_name}/fips-value?measure={encoded_measure}"
+
+                if factors is not None:
+                    path += "&filters=" + quote_plus(";".join(factors))
+
+                response = client.get(path)
+
+                assert response.status_code == 200, path
+                data = response.json()
+
+                assert "values" in data and len(data["values"]) > 0, path
+
+def test_measuremapper_scp_model_populated():
+    """
+    Test that we can set a model on a MeasureMapper object and then query
+    it to get measures. We'd ordinarily hardcode the measures in the metadata,
+    but in this case the measures might change so we reflect it from the data.
+
+    Note that this requires a database populated with the SCP data, so
+    it's technically an integration test.
+    """
+
+    for model in SCP_CANCER_MODELS:
+        mapper = MeasureMapper(MeasureUnit.RATE, model=model, measure_column="Site")
+
+        test_measure = "All Cancer Sites"
+
+        # see that our key accesses recapitulate the received keys
+        assert mapper[test_measure]["unit"] == MeasureUnit.RATE
+        assert mapper[test_measure]["label"] == test_measure
+
+        # check that we're seeing greater than zero elements
+        assert len([x for x in mapper]) > 0

--- a/backend/app/tests/integration/test_units_in_response.py
+++ b/backend/app/tests/integration/test_units_in_response.py
@@ -3,14 +3,14 @@ import pytest
 from urllib.parse import quote_plus
 
 import sys
-sys.path.append("/app")
+sys.path.append("/app/src")
 
 from models.base import STATS_MODELS, MEASURE_DESCRIPTIONS
 from tools.strings import slug_modelname_sans_type
 
-pytestmark = pytest.mark.asyncio
 
-async def test_unit_in_response(client):
+@pytest.mark.asyncio(loop_scope='function')
+async def test_unit_in_response(event_loop, client):
     for type in STATS_MODELS:
         for model in STATS_MODELS[type]:
             simple_model_name = slug_modelname_sans_type(model, type)

--- a/backend/app/tests/metadata_integrity/test_dataset_metadata.py
+++ b/backend/app/tests/metadata_integrity/test_dataset_metadata.py
@@ -1,0 +1,138 @@
+
+import os
+import glob
+import csv
+import re
+
+import pytest
+
+from models.cif_meta import CIF_MEASURE_DESCRIPTIONS
+
+# skip the test if the folder `/data/staging` doesn't exist
+needs_cif_staging = pytest.mark.skipif(
+    not os.path.exists("/data/staging"),
+    reason="Path /data/staging doesn't exist, so can't test CiF data agreement"
+)
+
+@needs_cif_staging
+def test_cif_metadata_data_agreement():
+    """
+    Tests that the metadata we have harcoded for the CancerInFocus datasets
+    matches the spreadsheets for a specific CIF dataset distribution.
+    """
+
+    CIF_DATASHEETS = "/data/staging/2024-10/stats/*_long*.csv"
+
+    sheets = glob.glob(CIF_DATASHEETS)
+
+    # ensure that we have the same number of metadata categories
+    # as we do input sheets
+    # (we share metadata between county and tract measure categories,
+    # so first we have to remove the county/tract specifier, then
+    # check if that unique set is the same length as the measure descs)
+    # match filenames like this: us_food_desert_tract_long_07-01-2024.csv
+    # to extract "food_desert"
+    assert (
+        len(
+            set(
+                re.match(r"us_(.*)_(county|tract)_long_.*\.csv", os.path.split(x)[1]).groups()[0]
+                for x in sheets
+            )
+        ) ==
+        len(CIF_MEASURE_DESCRIPTIONS)
+    )
+
+    SHEETS_TO_MEASURES = {
+        "us_cancer_incidence_county": "cancerincidence",
+        "us_cancer_mortality_county": "cancermortality",
+        "us_economy_county": "economy",
+        "us_environment_county": "environment",
+        "us_housing_trans_county": "housingtrans",
+        "us_rf_and_screening_county": "rfandscreening",
+        "us_sociodemographics_county": "sociodemographics",
+        "us_disparity_county": "disparities",
+        "us_economy_tract": "economy",
+        "us_environment_tract": "environment",
+        "us_food_desert_tract": "fooddesert",
+        "us_housing_trans_tract": "housingtrans",
+        "us_rf_and_screening_tract": "rfandscreening",
+        "us_sociodemographics_tract": "sociodemographics",
+        "us_disparity_tract": "disparities",
+    }
+
+    # actual files:
+    # 1. us_cancer_incidence_county
+    # 2. us_cancer_mortality_county
+    # 3. us_economy_county
+    # 4. us_environment_county
+    # 5. us_housing_trans_county
+    # 6. us_rf_and_screening_county
+    # 7. us_sociodemographics_county
+    # 8. us_disparity_county
+
+    # iterate over each sheet in the CIF_DATASHEETS glob
+    for sheet in sheets:
+        # isolate just the filename of the sheet using os.path.split
+        filename = os.path.split(sheet)[1]
+
+        # if we're looking at tract data, we ignore measure metadata
+        # that has the 'county_only' field set to true
+        is_tract = "_tract_" in filename
+
+        # skip cancer sheets for now, since we're not using them
+        if "cancer" in filename:
+            continue
+
+        # read the sheet using the csv.DictReader reader
+        with open(sheet, 'r') as f:
+            reader = csv.DictReader(f)
+
+            distinct_measures = set()
+
+            if 'cancer' not in sheet:
+                # each sheet has these columns:
+                # FIPS,County,State,measure,value
+                # we're interested in checking that the intersection
+                # between the unique values of measure and the 
+                for row in reader:
+                    distinct_measures.add(row['measure'])
+            else:
+                # FIPS,County,State,Type,RE,Sex,Site,AAR,AAC
+                for row in reader:
+                    distinct_measures.add(row['Site'])
+
+            # for some reason CIF adds the month to "Monthly Unemployment Rate"
+            # for each release, but we remove it so that it matches our
+            # "Monthly Unemployment Rate" metadata entry. we'll remove
+            # it here as well so the test passes
+            distinct_measures = set(
+                re.sub(r"Monthly Unemployment Rate (.*)", "Monthly Unemployment Rate", x)
+                for x in distinct_measures
+            )
+
+            # also, CIF's tract economoy data doesn't include "Monthly Unemployment Rate"
+            # so if we're looking at the tract remove
+
+            # check if a key from SHEETS_TO_MEASURES is in the filename
+            # of the sheet
+            try:
+                model_name = next(
+                    v for k, v in SHEETS_TO_MEASURES.items() if k in filename
+                )
+            except StopIteration:
+                raise Exception(f"Could not find model for file {sheet}")
+
+            # skip county-only measures when testing tracts
+            # and tract-only measures when testing counties
+            # (looking at you 'environment', where the tract data and
+            # county data are *completely* different)
+            measures = {
+                k: v for k, v in
+                CIF_MEASURE_DESCRIPTIONS[model_name].items()
+                if (
+                    is_tract and not v.get("county_only", False) or
+                    not is_tract and not v.get("tract_only", False)
+                )
+            }
+
+            assert set(measures.keys()) == distinct_measures, f"measures mismatch for {sheet} versus model {model_name}"

--- a/backend/app/tools/collections.py
+++ b/backend/app/tools/collections.py
@@ -4,8 +4,12 @@ but generate the values on the fly.
 """
 
 from collections.abc import Mapping
+from typing import ItemsView
 
-from models.base import MeasureUnit
+from sqlmodel import select
+
+from db import get_sync_session
+from models.base import BaseStatsModel, MeasureUnit
 
 class MeasureMapper(Mapping):
     """
@@ -18,11 +22,34 @@ class MeasureMapper(Mapping):
 
     Also supports a dictionary of extras, which can be used to add information
     to each request for a key.
+
+    If 'model' is provided, issues queries against the model for the
+    measures that it contains. Uses 'measure_column' as the column name for
+    the measure in the model (for regulare measures, this is 'measure', but
+    for cancer models, it's 'Site').
     """
 
-    def __init__(self, default_unit: MeasureUnit, extras: dict=None):
+    def __init__(self, default_unit: MeasureUnit, extras: dict=None, model: BaseStatsModel = None, measure_column: str = "measure"):
         self.default_unit = default_unit
         self.extras = extras or {}
+        self.model = model
+        self.measure_column = measure_column
+        # cache for unique values of the measure column
+        self._model_measures = None
+
+    def _get_measures(self):
+        if not self.model:
+            return []
+        
+        if self._model_measures is None:
+            # query for unique values of the measure column
+            with get_sync_session() as session:
+                query = select(getattr(self.model, self.measure_column)).distinct()
+                result = session.execute(query)
+                self._model_measures = result.scalars().all()
+
+        return self._model_measures
+
 
     def __getitem__(self, key):
         return {**{"label": key, "unit": self.default_unit}, **self.extras}
@@ -35,14 +62,23 @@ class MeasureMapper(Mapping):
         Returns 0, since the object has virtual keys and thus
         there's nothing to count.
         """
-        return 0
+
+        return len(self._get_measures())
 
     def __iter__(self):
         """
-        Returns an empty iterator, since the object has virtual keys and thus
-        there's nothing to iterate over.
+        If a model was provided, attempts create an iterator over its measures.
+        If not, returns an empty iterator, since the object has virtual keys and
+        thus there's nothing to iterate over.
         """
-        return iter([])
+        return iter([
+            k for k in self._get_measures()
+        ])
+    
+    def items(self) -> ItemsView:
+        return iter([
+            (k, self.get(k)) for k in self._get_measures()
+        ])
     
     def __repr__(self):
         return f"MeasureMapper(default_unit={self.default_unit})"

--- a/backend/app/tools/queries.py
+++ b/backend/app/tools/queries.py
@@ -1,0 +1,211 @@
+"""
+Utilities for producing common queries or parts of queries
+over the entities in the ECCO data model.
+"""
+
+
+from collections import defaultdict
+from typing import Any
+from models import CANCER_MODELS, FACTOR_DESCRIPTIONS
+from models.base import BaseStatsModel
+from models.scp import SCP_TRENDS_MODELS
+from tools.accessors import omit
+from tools.strings import slug_modelname_sans_type
+
+
+from sqlalchemy import and_, or_, distinct, func
+from sqlmodel import select
+
+
+async def get_category_factors_with_values(model:BaseStatsModel, type:str, session, measures:list[str]=None):
+    """
+    Given a model (i.e. measure category), produces factors and the set of
+    factor values observed in the data for each measure under that category. If
+    'measures', a list, is supplied, filters the response down to just those
+    measures.
+
+    Response is of the form:
+    {
+        <measure>: {
+            <factor>: {
+                "label": str,
+                "default": str,
+                "values": {
+                    <value:str>: <label:str>
+                }
+            }
+        }
+    }
+    """
+
+    # retrieve metadata about the factors for the given model+type
+    simple_model_name = slug_modelname_sans_type(model, type)
+    factor_descs = FACTOR_DESCRIPTIONS.get(simple_model_name, {})
+
+    # if there are no factors, return an empty dict
+    if not factor_descs:
+        return {}
+
+    # determine the measure column ('Site' for cancer-related, 'measure' otherwise)
+    measure_col = (
+        model.Site
+        if model in CANCER_MODELS or model in SCP_TRENDS_MODELS else
+        model.measure
+    ).label("measure")
+
+    # select a list of all distinct factor values for each measure...
+    select_factor_args = [
+        func.array_agg(distinct(getattr(model, col))).label(col)
+        for col in factor_descs
+    ]
+    # ...but only for factor values that actually occur in the measure
+    having_factor_args = [
+        func.count(distinct(getattr(model, col))) > 0
+        for col in factor_descs
+    ]
+
+    # query for all factor values for each measure
+    query = (
+        select(
+            measure_col,
+            *select_factor_args
+        )
+        .group_by(measure_col)
+        .having(and_(*having_factor_args))
+        .distinct()
+    )
+
+    if measures is not None:
+        query = query.where(measure_col.in_(measures))
+
+    result = await session.execute(query)
+    factor_results = result.mappings().all()
+
+    # produce a response that looks very much like the factor response
+    # for a specific measure, but over all measures
+    return {
+        x["measure"]: {
+            k: {
+                "label": str(factor_descs[k]["label"] or k),
+                "default": factor_descs[k].get("default"),
+                "values": {
+                    value: label
+                    for value, label in factor_descs[k]["values"].items() if
+                    value in v
+                }
+            }
+            for k, v in omit(x, 'measure').items()
+        }
+        for x in factor_results
+    }
+
+def factor_default_clauses(constraints:dict[str,dict[str,Any]], model:BaseStatsModel, measure_col:str):
+    """
+    Converts a factor constraints dict to a set of clauses that can be applied
+    to a query for a specific model, to limit the results to the factor values
+    specified for each measure. The constraints dict is of the following form:
+    { <measure>: { <factor>: <value> } }.
+
+    Returns a clause for use in the 'where' portion of a query, consisting of:
+    1. A set of 'and' clauses, each of which specifies a measure and, for
+       each factor in the model, a value on which to filter.
+    3. An 'or' clause that combines all of the 'and' clauses.
+
+    :param constraints: a dict of the form { <measure>: { <factor>: <value> } }
+    :param model: an instance of the model class to query
+    :param measure_col: the column in the model that contains the measure
+    :return: a clause that can be applied to a query to limit the results to
+        the factor values specified in the constraints dict
+    """
+    clauses = []
+
+    for measure, factor_values in constraints.items():
+        clauses += [
+            and_(
+                measure_col == measure,
+                *[
+                    getattr(model, factor) == default
+                    for factor, default in factor_values.items()
+                ]
+            ).self_group()
+        ]
+
+    # OR all of the clauses together and return that
+    return or_(*clauses).self_group()
+
+async def get_model_factor_defaults_clause(model, type, session, measures:list[str]=None, choices:dict[str,dict[str,Any]]=None):
+    """
+    For a given model, returns a clause that can be applied to a query to limit
+    the results to either the populated factor values for each measure, or the
+    default factor values if no data is present for a given measure.
+
+    :param model: an instance of the model class to query
+    :param type: the type of the model (e.g. 'county', 'tract')
+    :param session: a database session
+    :param measures: an optional list of measures to constrain the query
+    :param choices: an optional dict of the form { <measure>: { <factor>: <value> } }
+        that specifies the factor values to use for each measure, overriding the
+        defaults. If a measure is not present in this dict, the default factor
+        values will be used.
+    :return: a tuple of the form (factor_constraints, factor_default_clause);
+        the first element is a dict of the form `{ <measure>: { <factor>: <value> } }`
+        that specifies the applied factor values for each measure, and the second
+        element is a clause that can be applied to a query to limit the results to
+        the factor values specified in the first element.
+    """
+
+    # first, resolve the 'simple' model name (i.e., normalized and without the
+    # geometry type) so we can retrieve the factor defaults from the metadata
+    simple_model_name = slug_modelname_sans_type(model, type)
+
+    # if the model has factors, constrain them to their default values
+    # for example, for SCP models, this selects the following factor values:
+    # "sex": "All", "stage": "All Stages", "race": "All Races (includes Hispanic)", "age": "All Ages"
+    factor_labels = FACTOR_DESCRIPTIONS.get(simple_model_name, None)
+    all_factor_values = await get_category_factors_with_values(model, type, session, measures=measures)
+
+    # determine the measure column ('Site' for cancer-related, 'measure' otherwise)
+    measure_col = (
+        model.Site
+        if model in CANCER_MODELS or model in SCP_TRENDS_MODELS else
+        model.measure
+    ).label("measure")
+
+    # record the factor constraints so we can apply them to both our queries
+    factor_constraints = defaultdict(dict)
+
+    if factor_labels:
+        for f, fv in factor_labels.items():
+            for measure in all_factor_values:
+                # if a choice was specified for this measure in choices, just
+                # use that and abort
+                if choices and measure in choices and f in choices[measure]:
+                    factor_constraints[measure][f] = choices[measure][f]
+                    continue
+
+                # get a list of observed factor values for this measure
+                # (we get .keys() here because those are the 'internal' factor
+                # names; the .values() portion of the dict is the human-readable
+                # labels)
+                measure_values = list(all_factor_values[measure][f]["values"].keys())
+
+                # this is the hardcoded default value, regardless of what's in the data
+                naive_default = fv.get("default")
+
+                if len(measure_values) > 0:
+                    # get the default if it occurs in the data
+                    # otherwise get the first value that actually occurs
+                    effective_default = naive_default if naive_default in measure_values else measure_values[0]
+                else:
+                    # we have no data for this factor, so just use the default
+                    effective_default = fv.get("default")
+
+                # populate factor_constraints with the effective default
+                factor_constraints[measure][f] = effective_default
+
+        # create a big OR'd where here, because each measure has its own set of possible factor values
+        factor_clause = factor_default_clauses(factor_constraints, model, measure_col)
+
+        return factor_constraints, factor_clause
+
+    return factor_constraints, None


### PR DESCRIPTION
This PR addresses issues that lead to PR #93 having to be rolled back. Specifically, the query that was being created to constrain factor values to just values that actually occur in the dataset had a few issues:
- the double-for loop comprehension I was using had some kind of issue that went away when I switched to a less-clever nested for loop
- part of it was indented incorrectly, leading to multiple redundant clauses being added to the query

The PR also factors out the factor resolution code into a new "helper" module, `queries.py`. We may use the code in other parts of the stack, e.g. in either the `fips-value` endpoint code to resolve factor values when none have been supplied (currently it just uses the default values), or possibly in the `measures` endpoint to dynamically provide more useful factor value defaults than what we've hardcoded.

The PR adds the ability for `MeasureMapper` to optionally provide a list of measures observed in the data when given a model. The change was mostly to support testing SCP ("State Cancer Profiles") models: we iterate over all of the measure categories and measures using the metadata, and since the metadata  for SCP is dynamically created (unlike for CancerInFocus, where  measure is hardcoded in the metadata) this was previously impossible. Since we can't be sure `MeasureMapper` will be used from an async context, I've added support functions to `db.py` to get a synchronous session, which is used in `MeasureMapper`.

Finally, the PR includes a few new tests and organizes the existing ones into subfolders. I added a README to help explain the organization scheme. There are a few other minor changes to tests, e.g. updating pytest annotations and skipping tests that can't be completed in production due to the ingest data not being present.

**Things to try:**
- bring up the stack via `./run_stack.sh` and see that it completes
- enter the backend container via `./run_stack.sh shell` and run `pytest` to see that the tests complete (they should take ~3 minutes)
- while a test exists to compare by-county to fips-value values, feel free to spot-check the values shown via tooltips on the map against the ones in the by-county view