### PR TITLE
improve chart component

### DIFF
--- a/frontend/src/components/AppMap.vue
+++ b/frontend/src/components/AppMap.vue
@@ -82,6 +82,17 @@
 
 <script lang="ts">
 type FeatureInfo = Record<string, unknown>;
+
+/** "no data" color */
+const noDataColor = "#a0a0a0";
+
+/** "no data scale entry */
+export const noDataEntry = {
+  value: "",
+  label: "ND",
+  color: noDataColor,
+  tooltip: "No data or suppressed value",
+} as const;
 </script>
 
 <script setup lang="ts">
@@ -109,17 +120,6 @@ import { formatValue, normalizedApply } from "@/util/math";
 import { getBbox, sleep } from "@/util/misc";
 import "leaflet/dist/leaflet.css";
 import { capitalize } from "@/util/string";
-
-/** "no data" color */
-let noDataColor = "#a0a0a0";
-
-/** "no data scale entry */
-const noDataEntry = {
-  value: "",
-  label: "ND",
-  color: noDataColor,
-  tooltip: "No data, suppressed value, or 0",
-};
 
 /** element refs */
 const scrollElement = ref<HTMLDivElement>();

--- a/frontend/src/pages/PageCounty.vue
+++ b/frontend/src/pages/PageCounty.vue
@@ -64,7 +64,7 @@
             :title="chart.title"
             :data="chart.data"
             :unit="chart.unit"
-            :enumerated="chart.unit === 'ordinal'"
+            :order="chart.order"
           />
         </div>
       </template>
@@ -241,6 +241,8 @@ const chartData = computed(() =>
         return {
           title,
           unit: Object.values(measureValues).find((value) => value?.unit)?.unit,
+          order: Object.values(measureValues).find((value) => value?.order)
+            ?.order,
           data: {
             County: mapValues(measureValues, (value) => value?.value),
             ...(showStateLevel && {


### PR DESCRIPTION
Make improvements to chart component following #103 

- compute unique x and y axis values at start
- sort y values in provided order if applicable
- use common "noDataEntry" variable, shared between components, for "no data" color, short label, long label, etc.
- pass value order (when unit == "ordinal") from backend to chart component for y-axis label ordering