### PR TITLE
February 2025 Database Update

### DIFF
--- a/backend/app/models/cif_meta.py
+++ b/backend/app/models/cif_meta.py
@@ -8,807 +8,1070 @@ data is so verbose that i decided to split it into a separate module.)
 from .base import MeasureUnit
 
 CIF_MEASURE_DESCRIPTIONS = {
-    "sociodemographics": {
-        "18 to 64": {
-            "label": "18 to 64 Years Old",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Advanced Degree": {
-            "label": "Completed a Graduate Degree",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Asian": {
-            "label": "Asian (non-Hispanic)",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Below 9th grade": {
-            "label": "Did Not Attend High School",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Black": {
-            "label": "Black (non-Hispanic)",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "College": {
-            "label": "Graduated College",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "High School": {
-            "label": "Graduated High School",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Hispanic": {
-            "label": "Hispanic",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        # moved to disparities as of 2024-09
-        # "Lack_English_Prof": {
-        #     "label": "Lack Proficiency in English",
-        #     "unit": MeasureUnit.PERCENT,
-        # },
-        "Other_Races": {
-            "label": "Other Non-Hispanic Race",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Over 64": {
-            "label": "Over 64 Years Old",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Total": {
-            "label": "Total Population",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.COUNT
-        },
-        "Under 18": {
-            "label": "Under 18 Years Old",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Urban_Percentage": {
-            "label": "Urbanized Residents",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-            "county_only": True
-        },
-        "White": {
-            "label": "White (non-Hispanic)",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
+  "sociodemographics": {
+    "Total": {
+      "label": "Total Population",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.COUNT
     },
-    "economy": {
-        "Annual Labor Force Participation Rate": {
-            "label": "Annual Labor Force Participation",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Annual Unemployment Rate": {
-            "label": "Annual Unemployment Rate",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Below Poverty": {
-            "label": "Living Below Poverty",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        # moved to rfandscreening as of 2024-09
-        # "Gini Coefficient": {
-        #     "label": "Income Inequality (Gini Coefficient)",
-        #     "unit": MeasureUnit.PERCENT,
-        # },
-        "Household Income": {
-            "label": "Household Income ($)",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.DOLLAR_AMOUNT,
-        },
-        "Insurance Coverage": {
-            "label": "Insured",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Medicaid Enrollment": {
-            "label": "Enrolled in Medicaid",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Monthly Unemployment Rate": {
-            "label": "Monthly Unemployment Rate",
-            "unit": MeasureUnit.PERCENT,
-            "county_only": True
-        },
-        "Received Public Assistance": {
-            "label": "Received TANF or SNAP Public Assistance",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Uninsured": {
-            "label": "Uninsured",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
+    "Under 18": {
+      "label": "Under 18 Years Old",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
     },
-    # environment is now completely different between counties
-    # and tracts; we'll use the county_only and tract_only fields
-    # to differentiate between the two, e.g. for tests
-    "environment": {
-        # county fields
-        "LILATracts_Vehicle": {
-            "label": "Tracts that are Food Deserts",
-            "unit": MeasureUnit.PERCENT,
-            "county_only": True
-        },
-        # missing as of the 2024-04 release?
-        # "PWS_Violations_Since_2016": {
-        #     "label": "Public Water System Violations since 2016",
-        #     "unit": MeasureUnit.COUNT,
-        #     "county_only": True
-        # },
-        "pct5G_35_3": {
-            "label": "Area with 35/3 Mbps Mobile 5G Coverage",
-            "unit": MeasureUnit.PERCENT,
-            "county_only": True
-        },
-        "pct5G_7_1": {
-            "label": "Area with 7/1 Mbps Mobile 5G Coverage",
-            "unit": MeasureUnit.PERCENT,
-            "county_only": True
-        },
-        "pctBB_100_20": {
-            "label": "Housing Units with 100/20 Mbps Broadband Service",
-            "unit": MeasureUnit.PERCENT,
-            "county_only": True
-        },
-        "pctBB_1000_10": {
-            "label": "Housing Units with 1000/10 Mbps Broadband Service",
-            "unit": MeasureUnit.PERCENT,
-            "county_only": True
-        },
-        # tract fields
-        # FIXME: validate labels, units against CIF site
-        # introduced in 2024-07 release, removed in 2024-09 release?
-        # "Air Toxics Cancer": {
-        #     "label": "Air Toxics Cancer Risk",
-        #     "unit": MeasureUnit.RATE,
-        #     "tract_only": True
-        # },
-        # "Air Toxics Resp": {
-        #     "label": "Air Toxics Respiratory Risk",
-        #     "unit": MeasureUnit.RATE,
-        #     "tract_only": True
-        # },
-        "Diesel PM": {
-            "label": "Diesel Particulate Matter (annual avg. mcg/m^3)",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Drinking Water Noncompliance": {
-            "label": "Drinking Water Non-Compliance",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Hazardous Waste Proximity": {
-            "label": "Hazardous Waste Proximity",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Lead Paint": {
-            "label": "Housing Units Built Pre-1960",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Nitrogen Dioxide": {
-            "label": "Nitrogen Dioxide (annual avg. part per billion)",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Ozone": {
-            "label": "Annual Ozone Average (ppm)",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "PM25": {
-            "label": "Particulate Matter 2.5 (annual avg. mcg/m^3)",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "RMP Proximity": {
-            "label": "Risk Management Plan Facility Proximity",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Superfund Proximity": {
-            "label": "Superfund Proximity",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Toxics Release to Air": {
-            "label": "Toxic Releases to Air",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Traffic Proximity": {
-            "label": "Traffic Volume",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Underground Storage Tanks": {
-            "label": "Underground Storage Tanks",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
-        "Water Discharge": {
-            "label": "Toxic Water Discharge",
-            "source": "EJScreen, 2023",
-            "source_url": "https://www.epa.gov/ejscreen",
-            "unit": MeasureUnit.RATE,
-            "tract_only": True
-        },
+    "18 to 64": {
+      "label": "18 to 64 Years Old",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
     },
-    "housingtrans": {
-        "Crowded Housing": {
-            "label": "Crowded Homes",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Lack Complete Plumbing": {
-            "label": "Homes without Complete Plumbing",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Median Gross Rent": {
-            "label": "Median Gross Rent ($)",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.DOLLAR_AMOUNT,
-        },
-        "Median Home Value": {
-            "label": "Median Home Value ($)",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.DOLLAR_AMOUNT,
-        },
-        "Median Monthly Mortgage": {
-            "label": "Median Monthly Mortgage ($)",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.DOLLAR_AMOUNT,
-        },
-        "Mobile Homes": {
-            "label": "Housing in Mobile Homes",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Multi-Unit Structures": {
-            "label": "Housing in Multi-Unit Structures",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "No Home Broadband": {
-            "label": "Homes without Broadband Internet",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "No Vehicle": {
-            "label": "No Household Vehicle Access",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Owner Occupied Housing": {
-            "label": "Owner-occupied Housing Units",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Rent Burden (40% Income)": {
-            "label": "High Rent Burden",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Single Parent Household": {
-            "label": "Single Parent Homes",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Vacancy Rate": {
-            "label": "Vacant Housing",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
+    "Over 64": {
+      "label": "Over 64 Years Old",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
     },
-    "rfandscreening": {
-        "Asthma": {
-            "label": "Diagnosed with Asthma",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Bad_Health": {
-            "label": "Report Fair or Poor Overall Health",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Binge_Drinking": {
-            "label": "Binge Drink",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "BMI_Obese": {
-            "label": "Obese (BMI over 30)",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "BP_Medicine": {
-            "label": "On Blood Pressure Medication",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Cancer_Prevalence": {
-            "label": "History of Cancer Diagnosis",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Cognitive_Disability": {
-            "label": "Cognitive Disability",
-            "unit": MeasureUnit.PERCENT
-        },
-        "CHD": {
-            "label": "Have Coronary Heart Disease",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "COPD": {
-            "label": "Have COPD",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Currently_Smoke": {
-            "label": "Currently Smoke (adults)",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Depression": {
-            "label": "Have Depression",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Diabetes_DX": {
-            "label": "Diagnosed with Diabetes",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Food_Insecure": {
-            "label": "Experienced Food Insecurity in Last 12 Months",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Had_Stroke": {
-            "label": "Had a Stroke",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Hearing_Disability": {
-            "label": "Hearing Disability",
-            "unit": MeasureUnit.PERCENT
-        },
-        "High_BP": {
-            "label": "Have High Blood Pressure",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        # removed in 2024-09 release?
-        # "Kidney_Disease": {
-        #     "label": "Have Chronic Kidney Disease",
-        #     "unit": MeasureUnit.PERCENT,
-        # },
-        "High_Cholesterol": {
-            "label": "Have High Cholesterol",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Housing_Insecure": {
-            "label": "Experienced Housing Insecurity in Last 12 Months",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Independent_Living_Disability": {
-            "label": "Independent Living Disability",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Lacked_Reliable_Transportation": {
-            "label": "Lacked Reliable Transportation in Last 12 Months",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Lacked_Social_Emotional_Support": {
-            "label": "Lacked Social/Emotional Support in Last 12 Months",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Met_Breast_Screen": {
-            "label": "Met Breast Screening Recommendations",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        # removed in 2024-09 release?
-        # "Met_Cervical_Screen": {
-        #     "label": "Met Cervical Screening Recommendations",
-        #     "unit": MeasureUnit.PERCENT,
-        # },
-        "Met_Colon_Screen": {
-            "label": "Met Colorectal Screening Recommendations",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Mobility_Disability": {
-            "label": "Mobility Disability",
-            "unit": MeasureUnit.PERCENT
-        },
-        "No_Teeth": {
-            "label": "All Adult Teeth Lost",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Physically_Inactive": {
-            "label": "Physically Inactive",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Poor_Mental": {
-            "label": "Report Frequent Mental Health Distress",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Poor_Physical": {
-            "label": "Report Frequent Physical Health Distress",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Recent_Checkup": {
-            "label": "Had a Medical Checkup in the Last Year",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Recent_Dentist": {
-            "label": "Had a Dental Visit in the Last Year",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Selfcare_Disability": {
-            "label": "Self-care Disability",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Sleep_Debt": {
-            "label": "Sleep < 7 Hours a Night",
-            "source": "CDC Places, 2022",
-            "source_url": "https://www.cdc.gov/places/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Socially_Isolated": {
-            "label": "Felt Socially Isolated in Last 12 Months",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Vision_Disability": {
-            "label": "Vision Disability",
-            "unit": MeasureUnit.PERCENT
-        },
+    "White": {
+      "label": "White (non-Hispanic)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
     },
-    "fooddesert": {
-        "LILATracts_Vehicle": {
-            "label": "Tracts that are Food Deserts",
-            "source": "USDA ERS, 2019",
-            "source_url": "https://www.ers.usda.gov/data-products/food-access-research-atlas/",
-            "unit": MeasureUnit.PERCENT,
-        },
+    "Black": {
+      "label": "Black (non-Hispanic)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
     },
-    "disparities": {
-        "Living Below Poverty (Black)": {
-            "label": "Black Population Living Below Poverty",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Uninsured (Black)": {
-            "label": "Black Population without Health Insurance",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Uninsured Children": {
-            "label": "Children without Health Insurance",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Economic Segregation": {
-            "label": "Economic Segregation",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.LEAST_MOST,
-        },
-        "Gender Pay Gap": {
-            "label": "Gender Pay Gap",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT
-        },
-        "Living Below Poverty (Hispanic)": {
-            "label": "Hispanic Population Living Below Poverty",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Uninsured (Hispanic)": {
-            "label": "Hispanic Population without Health Insurance",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Gini Coefficient": {
-            "label": "Income Inequality (Gini Coefficient)",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
-        "Racial Economic Segregation": {
-            "label": "Racial Economic Segregation",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.LEAST_MOST,
-        },
-        "Racial Segregation": {
-            "label": "Racial Segregation",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.LEAST_MOST,
-        },
-        "Lack_English_Prof": {
-            "label": "Lack Proficiency in English",
-            "source": "ACS 5-Year, 2017 - 2021",
-            "source_url": "https://data.census.gov/",
-            "unit": MeasureUnit.PERCENT,
-        },
+    "AIAN": {
+      "label": "American Indian and Alaska Native (non-Hispanic)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
     },
-    "cancerincidence": {
-        "All Site": {
-            "label": "All Cancer Sites",
-            "unit": MeasureUnit.RATE
-        },
-        "Bladder": {
-            "label": "Bladder",
-            "unit": MeasureUnit.RATE
-        },
-        "Brain & ONS": {
-            "label": "Brain & ONS",
-            "unit": MeasureUnit.RATE
-        },
-        "Cervix": {
-            "label": "Cervix",
-            "unit": MeasureUnit.RATE
-        },
-        "Colon & Rectum": {
-            "label": "Colon & Rectum",
-            "unit": MeasureUnit.RATE
-        },
-        "Corpus Uteri & Uterus, NOS": {
-            "label": "Corpus Uteri & Uterus, NOS",
-            "unit": MeasureUnit.RATE,
-        },
-        "Esophagus": {
-            "label": "Esophagus",
-            "unit": MeasureUnit.RATE
-        },
-        "Female Breast": {
-            "label": "Female Breast",
-            "unit": MeasureUnit.RATE
-        },
-        "Kidney & Renal Pelvis": {
-            "label": "Kidney & Renal Pelvis",
-            "unit": MeasureUnit.RATE,
-        },
-        "Leukemia": {
-            "label": "Leukemia",
-            "unit": MeasureUnit.RATE
-        },
-        "Liver & IBD": {
-            "label": "Liver & IBD",
-            "unit": MeasureUnit.RATE
-        },
-        "Lung & Bronchus": {
-            "label": "Lung & Bronchus",
-            "unit": MeasureUnit.RATE
-        },
-        "Melanoma of the Skin": {
-            "label": "Melanoma of the Skin",
-            "unit": MeasureUnit.RATE,
-        },
-        "Non-Hodgkin Lymphoma": {
-            "label": "Non-Hodgkin Lymphoma",
-            "unit": MeasureUnit.RATE,
-        },
-        "Oral Cavity & Pharynx": {
-            "label": "Oral Cavity & Pharynx",
-            "unit": MeasureUnit.RATE,
-        },
-        "Ovary": {
-            "label": "Ovary",
-            "unit": MeasureUnit.RATE
-        },
-        "Pancreas": {
-            "label": "Pancreas",
-            "unit": MeasureUnit.RATE
-        },
-        "Prostate": {
-            "label": "Prostate",
-            "unit": MeasureUnit.RATE
-        },
-        "Stomach": {
-            "label": "Stomach",
-            "unit": MeasureUnit.RATE
-        },
-        "Thyroid": {
-            "label": "Thyroid",
-            "unit": MeasureUnit.RATE
-        },
+    "Asian": {
+      "label": "Asian (non-Hispanic)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
     },
-    "cancermortality": {
-        "All Site": {
-            "label": "All Cancer Sites",
-            "unit": MeasureUnit.RATE
-        },
-        "Bladder": {
-            "label": "Bladder",
-            "unit": MeasureUnit.RATE
-        },
-        "Brain & ONS": {
-            "label": "Brain & ONS",
-            "unit": MeasureUnit.RATE
-        },
-        "Cervix": {
-            "label": "Cervix",
-            "unit": MeasureUnit.RATE
-        },
-        "Colon & Rectum": {
-            "label": "Colon & Rectum",
-            "unit": MeasureUnit.RATE
-        },
-        "Corpus Uteri & Uterus, NOS": {
-            "label": "Corpus Uteri & Uterus, NOS",
-            "unit": MeasureUnit.RATE,
-        },
-        "Esophagus": {
-            "label": "Esophagus",
-            "unit": MeasureUnit.RATE
-        },
-        "Female Breast": {
-            "label": "Female Breast",
-            "unit": MeasureUnit.RATE
-        },
-        "Kidney & Renal Pelvis": {
-            "label": "Kidney & Renal Pelvis",
-            "unit": MeasureUnit.RATE,
-        },
-        "Leukemia": {
-            "label": "Leukemia",
-            "unit": MeasureUnit.RATE
-        },
-        "Liver & IBD": {
-            "label": "Liver & IBD",
-            "unit": MeasureUnit.RATE
-        },
-        "Lung & Bronchus": {
-            "label": "Lung & Bronchus",
-            "unit": MeasureUnit.RATE
-        },
-        "Melanoma of the Skin": {
-            "label": "Melanoma of the Skin",
-            "unit": MeasureUnit.RATE,
-        },
-        "Non-Hodgkin Lymphoma": {
-            "label": "Non-Hodgkin Lymphoma",
-            "unit": MeasureUnit.RATE,
-        },
-        "Oral Cavity & Pharynx": {
-            "label": "Oral Cavity & Pharynx",
-            "unit": MeasureUnit.RATE,
-        },
-        "Ovary": {
-            "label": "Ovary",
-            "unit": MeasureUnit.RATE
-        },
-        "Pancreas": {
-            "label": "Pancreas",
-            "unit": MeasureUnit.RATE
-        },
-        "Prostate": {
-            "label": "Prostate",
-            "unit": MeasureUnit.RATE
-        },
-        "Stomach": {
-            "label": "Stomach",
-            "unit": MeasureUnit.RATE
-        },
-        "Thyroid": {
-            "label": "Thyroid",
-            "unit": MeasureUnit.RATE
-        },
+    "NHOPI": {
+      "label": "Native Hawaiian and Other Pacific Islander (non-Hispanic)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
     },
+    "Hispanic": {
+      "label": "Hispanic",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Other_Races": {
+      "label": "Other Non-Hispanic Race",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Below 9th grade": {
+      "label": "Did Not Attend High School",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "High School": {
+      "label": "Graduated High School",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "College": {
+      "label": "Graduated College",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Advanced Degree": {
+      "label": "Completed a Graduate Degree",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Urban_Percentage": {
+      "label": "Urbanized Residents",
+      "source": "US Census Bureau, 2020 Decennial Census",
+      "source_url": "https://www.census.gov/programs-surveys/decennial-census.html",
+      "unit": MeasureUnit.PERCENT,
+      "county_only": True
+    }
+  },
+  "economy": {
+    "Insurance Coverage": {
+      "label": "Insured",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Medicaid Enrollment": {
+      "label": "Enrolled in Medicaid",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Household Income": {
+      "label": "Household Income ($)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.DOLLAR_AMOUNT
+    },
+    "Annual Labor Force Participation Rate": {
+      "label": "Annual Labor Force Participation",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Annual Unemployment Rate": {
+      "label": "Annual Unemployment Rate",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Below Poverty": {
+      "label": "Living Below Poverty",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Received Public Assistance": {
+      "label": "Received TANF or SNAP Public Assistance",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Monthly Unemployment Rate": {
+      "label": "Monthly Unemployment Rate",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT,
+      "county_only": True
+    },
+    "Uninsured": {
+      "label": "Uninsured",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    }
+  },
+  "environment": {
+    "pctBB_1000_10": {
+      "label": "Housing Units with 1000/10 Mbps Broadband Service",
+      "source": "FCC, December 2023",
+      "source_url": "https://www.fcc.gov/",
+      "unit": MeasureUnit.PERCENT,
+      "county_only": True
+    },
+    "pctBB_100_20": {
+      "label": "Housing Units with 100/20 Mbps Broadband Service",
+      "source": "FCC, December 2023",
+      "source_url": "https://www.fcc.gov/",
+      "unit": MeasureUnit.PERCENT,
+      "county_only": True
+    },
+    "pct5G_7_1": {
+      "label": "Area with 7/1 Mbps Mobile 5G Coverage",
+      "source": "FCC, December 2023",
+      "source_url": "https://www.fcc.gov/",
+      "unit": MeasureUnit.PERCENT,
+      "county_only": True
+    },
+    "pct5G_35_3": {
+      "label": "Area with 35/3 Mbps Mobile 5G Coverage",
+      "source": "FCC, December 2023",
+      "source_url": "https://www.fcc.gov/",
+      "unit": MeasureUnit.PERCENT,
+      "county_only": True
+    },
+    "LILATracts_Vehicle": {
+      "label": "Tracts that are Food Deserts",
+      "source": "USDA ERS, 2019",
+      "source_url": "https://www.ers.usda.gov/data-products/food-access-research-atlas/",
+      "unit": MeasureUnit.PERCENT,
+      "county_only": True
+    },
+    "PM25": {
+      "label": "Particulate Matter 2.5 (annual avg. mcg/m^3)",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Lead Paint": {
+      "label": "Housing Units Built Pre-1960",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Diesel PM": {
+      "label": "Diesel Particulate Matter (annual avg. mcg/m^3)",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Toxics Release to Air": {
+      "label": "Toxic Releases to Air",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Traffic Proximity": {
+      "label": "Traffic Volume",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Water Discharge": {
+      "label": "Toxic Water Discharge",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Superfund Proximity": {
+      "label": "Superfund Proximity",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "RMP Proximity": {
+      "label": "Risk Management Plan Facility Proximity",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Hazardous Waste Proximity": {
+      "label": "Hazardous Waste Proximity",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Ozone": {
+      "label": "Annual Ozone Average (ppb)",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Underground Storage Tanks": {
+      "label": "Underground Storage Tanks",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Nitrogen Dioxide": {
+      "label": "Nitrogen Dioxide (average annual part per billion)",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    },
+    "Drinking Water Noncompliance": {
+      "label": "Drinking Water Non-Compliance",
+      "source": "EJScreen, 2024",
+      "source_url": "https://www.epa.gov/ejscreen",
+      "unit": MeasureUnit.RATE,
+      "tract_only": True
+    }
+  },
+  "housingtrans": {
+    "Vacancy Rate": {
+      "label": "Vacant Housing",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "No Vehicle": {
+      "label": "No Household Vehicle Access",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Single Parent Household": {
+      "label": "Single Parent Homes",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Multi-Unit Structures": {
+      "label": "Housing in Multi-Unit Structures",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Mobile Homes": {
+      "label": "Housing in Mobile Homes",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Owner Occupied Housing": {
+      "label": "Owner-occupied Housing Units",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Crowded Housing": {
+      "label": "Crowded Homes",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Lack Complete Plumbing": {
+      "label": "Homes without Complete Plumbing",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Median Home Value": {
+      "label": "Median Home Value ($)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.DOLLAR_AMOUNT
+    },
+    "Median Monthly Mortgage": {
+      "label": "Median Monthly Mortgage ($)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.DOLLAR_AMOUNT
+    },
+    "Median Gross Rent": {
+      "label": "Median Gross Rent ($)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.DOLLAR_AMOUNT
+    },
+    "No Home Broadband": {
+      "label": "Homes without Broadband Internet",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Rent Burden (40% Income)": {
+      "label": "High Rent Burden",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    }
+  },
+  "rfandscreening": {
+    "Met_Breast_Screen": {
+      "label": "Met Breast Screening Recommendations",
+      "source": "CDC PLACES, 2024  (HP2030 Goal: 80.5%)",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Met_Colon_Screen": {
+      "label": "Met Colorectal Screening Recommendations",
+      "source": "CDC PLACES, 2024 (HP2030 Goal: 74.4%)",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Currently_Smoke": {
+      "label": "Currently Smoke (adults)",
+      "source": "CDC PLACES, 2024 (HP2030 Goal: 6.1%)",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "BMI_Obese": {
+      "label": "Obese (BMI over 30)",
+      "source": "CDC PLACES, 2024 (HP2030 Goal: 36.0%)",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Physically_Inactive": {
+      "label": "Physically Inactive",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Binge_Drinking": {
+      "label": "Binge Drink",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Sleep_Debt": {
+      "label": "Sleep < 7 Hours a Night",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Cancer_Prevalence": {
+      "label": "History of Cancer Diagnosis",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Bad_Health": {
+      "label": "Report Fair or Poor Overall Health",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Poor_Physical": {
+      "label": "Report Frequent Physical Health Distress",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Poor_Mental": {
+      "label": "Report Frequent Mental Health Distress",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Depression": {
+      "label": "Have Depression",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Diabetes_DX": {
+      "label": "Diagnosed with Diabetes",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "High_BP": {
+      "label": "Have High Blood Pressure",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "High_Cholesterol": {
+      "label": "Have High Cholesterol",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "BP_Medicine": {
+      "label": "On Blood Pressure Medication",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "CHD": {
+      "label": "Have Coronary Heart Disease",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Had_Stroke": {
+      "label": "Had a Stroke",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Asthma": {
+      "label": "Diagnosed with Asthma",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "COPD": {
+      "label": "Have COPD",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "No_Teeth": {
+      "label": "All Adult Teeth Lost",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Recent_Checkup": {
+      "label": "Had a Medical Checkup in the Last Year",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Recent_Dentist": {
+      "label": "Had a Dental Visit in the Last Year",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Hearing_Disability": {
+      "label": "Hearing Disability",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Vision_Disability": {
+      "label": "Vision Disability",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Cognitive_Disability": {
+      "label": "Cognitive Disability",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Mobility_Disability": {
+      "label": "Mobility Disability",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Selfcare_Disability": {
+      "label": "Self-care Disability",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Independent_Living_Disability": {
+      "label": "Independent Living Disability",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Socially_Isolated": {
+      "label": "Felt Socially Isolated in Last 12 Months",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Food_Insecure": {
+      "label": "Experienced Food Insecurity in Last 12 Months",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Housing_Insecure": {
+      "label": "Experienced Housing Insecurity in Last 12 Months",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Lacked_Reliable_Transportation": {
+      "label": "Lacked Reliable Transportation in Last 12 Months",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Lacked_Social_Emotional_Support": {
+      "label": "Lacked Social/Emotional Support in Last 12 Months",
+      "source": "CDC PLACES, 2024",
+      "source_url": "https://www.cdc.gov/places/",
+      "unit": MeasureUnit.PERCENT
+    }
+  },
+  "fooddesert": {
+    "LILATracts_Vehicle": {
+      "label": "Tracts that are Food Deserts",
+      "source": "USDA ERS, 2019",
+      "source_url": "https://www.ers.usda.gov/data-products/food-access-research-atlas/",
+      "unit": MeasureUnit.PERCENT,
+      "tract_only": True
+    }
+  },
+  "disparities": {
+    "Gini Coefficient": {
+      "label": "Income Inequality (Gini Coefficient)",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.COUNT
+    },
+    "Economic Segregation": {
+      "label": "Economic Segregation",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.LEAST_MOST
+    },
+    "Racial Economic Segregation": {
+      "label": "Racial Economic Segregation",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.LEAST_MOST
+    },
+    "Racial Segregation": {
+      "label": "Racial Segregation",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.LEAST_MOST
+    },
+    "Gender Pay Gap": {
+      "label": "Gender Pay Gap",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.COUNT
+    },
+    "Uninsured Children": {
+      "label": "Children without Health Insurance",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Uninsured (Black)": {
+      "label": "Black Population without Health Insurance",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Uninsured (Hispanic)": {
+      "label": "Hispanic Population without Health Insurance",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Living Below Poverty (Black)": {
+      "label": "Black Population Living Below Poverty",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Living Below Poverty (Hispanic)": {
+      "label": "Hispanic Population Living Below Poverty",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    },
+    "Lack_English_Prof": {
+      "label": "Lack Proficiency in English",
+      "source": "ACS 5-Year, 2019 - 2023",
+      "source_url": "https://data.census.gov/",
+      "unit": MeasureUnit.PERCENT
+    }
+  },
+  "cancerincidence": {
+    "All Site": {
+      "label": "All Cancer Site ",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Bladder": {
+      "label": "Bladder Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Brain & ONS": {
+      "label": "Brain Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Cervix": {
+      "label": "Cervical Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Cervix (Early Stage)": {
+      "label": "Cervical Cancer (Early Stage)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Cervix (Late Stage)": {
+      "label": "Cervical Cancer (Late Stage)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Cervix (21-65 years)": {
+      "label": "Cervical Cancer (21-65 years)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Colon & Rectum": {
+      "label": "Colorectal Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Colon & Rectum (Early Stage)": {
+      "label": "Colorectal Cancer (Early Stage)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Colon & Rectum (Late Stage)": {
+      "label": "Colorectal Cancer (Late Stage)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Colon & Rectum (45-75 years)": {
+      "label": "Colorectal Cancer (45-75 years)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Corpus Uteri & Uterus, NOS": {
+      "label": "Uterine Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Esophagus": {
+      "label": "Esophageal Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Female Breast": {
+      "label": "Female Breast Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Female Breast (Early Stage)": {
+      "label": "Female Breast Cancer (Early Stage)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Female Breast (Late Stage)": {
+      "label": "Female Breast Cancer (Late Stage)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Female Breast (40-74 years)": {
+      "label": "Female Breast Cancer (40-74 years)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Kidney & Renal Pelvis": {
+      "label": "Kidney Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Leukemia": {
+      "label": "Leukemia",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Liver & IBD": {
+      "label": "Liver Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Lung & Bronchus": {
+      "label": "Lung Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Lung & Bronchus (Early Stage)": {
+      "label": "Lung Cancer (Early Stage)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Lung & Bronchus (Late Stage)": {
+      "label": "Lung Cancer (Late Stage)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Lung & Bronchus (50-80 years)": {
+      "label": "Lung Cancer (50-80 years)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Melanoma of the Skin": {
+      "label": "Melanoma",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Non-Hodgkin Lymphoma": {
+      "label": "Non-Hodgkin Lymphoma",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Oral Cavity & Pharynx": {
+      "label": "Oral Cavity and Pharynx Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Ovary": {
+      "label": "Ovarian Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Pancreas": {
+      "label": "Pancreatic Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Prostate": {
+      "label": "Prostate Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Stomach": {
+      "label": "Stomach Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Thyroid": {
+      "label": "Thyroid Cancer",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Alcohol-associated": {
+      "label": "Alcohol-associated Cancers",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "HPV-associated": {
+      "label": "HPV-associated Cancers",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Obesity-associated": {
+      "label": "Obesity-associated Cancers",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Tobacco-associated": {
+      "label": "Tobacco-associated Cancers",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Head and Neck": {
+      "label": "Head and Neck Cancers",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Pediatric (0-19 years)": {
+      "label": "Pediatric Cancers (0-19 years)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "AYA (15-39 years)": {
+      "label": "Adolescent and Young Adults Cancers (15-39 years)",
+      "source": "US Cancer Statistics, 2017 - 2021",
+      "source_url": "https://www.cdc.gov/united-states-cancer-statistics/index.html",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    }
+  },
+  "cancermortality": {
+    "All Site": {
+      "label": "All Cancer Site ",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Bladder": {
+      "label": "Bladder Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Brain & ONS": {
+      "label": "Brain Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Cervix": {
+      "label": "Cervical Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Colon & Rectum": {
+      "label": "Colorectal Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Corpus Uteri & Uterus, NOS": {
+      "label": "Uterine Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Esophagus": {
+      "label": "Esophageal Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Female Breast": {
+      "label": "Female Breast Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Kidney & Renal Pelvis": {
+      "label": "Kidney Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Leukemia": {
+      "label": "Leukemia",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Liver & IBD": {
+      "label": "Liver Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Lung & Bronchus": {
+      "label": "Lung Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Melanoma of the Skin": {
+      "label": "Melanoma",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Non-Hodgkin Lymphoma": {
+      "label": "Non-Hodgkin Lymphoma",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Oral Cavity & Pharynx": {
+      "label": "Oral Cavity and Pharynx Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Ovary": {
+      "label": "Ovarian Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Pancreas": {
+      "label": "Pancreatic Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Prostate": {
+      "label": "Prostate Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Stomach": {
+      "label": "Stomach Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    },
+    "Thyroid": {
+      "label": "Thyroid Cancer",
+      "source": "State Cancer Profiles, 2018 - 2022",
+      "source_url": "https://statecancerprofiles.cancer.gov/",
+      "unit": MeasureUnit.RATE,
+      "county_only": True
+    }
+  }
 }
 
 # region "Commentary On Measure Descriptions"

--- a/backend/app/tests/metadata_integrity/test_dataset_metadata.py
+++ b/backend/app/tests/metadata_integrity/test_dataset_metadata.py
@@ -21,7 +21,13 @@ def test_cif_metadata_data_agreement():
     matches the spreadsheets for a specific CIF dataset distribution.
     """
 
-    CIF_DATASHEETS = "/data/staging/2024-10/stats/*_long*.csv"
+    # identify the most recent timestamp in the staging folder
+    LATEST_STAGING = max(
+        glob.glob("/data/staging/*"),
+        key=os.path.getmtime
+    )
+
+    CIF_DATASHEETS = f"{LATEST_STAGING}/cif/stats/*_long*.csv"
 
     sheets = glob.glob(CIF_DATASHEETS)
 


### PR DESCRIPTION
This PR updates the database with the following data releases:
- the CancerInFocus Feburary 5th 2025 release
  - to access the release, go to https://cancerinfocus.org/ and click "Download Full US Dataset"
  - alternatively, this URL will always point to the latest release, https://cancerinfocus.org/public-data/Current/us.zip
- SCP scraped data, [February 10th, 2025 release](https://github.com/seandavi/state-cancer-profile-scraper/releases/tag/2025-02-10)

The PR updates metadata for CancerInFocus that matches their latest release as well as the measure dictionary (`stats/measure_dictionary_v5.csv` in the most recent release) that they've recently started including with their data release archives.

**How to test:**

If you have the stack running, bring it down. Run `./run_stack.sh` to bring it back up; the new release should be loaded automatically when the database container starts. Browse the site at http://localhost:8001 to see the updated data.