### PR TITLE
hide extra outreach info in tooltip unless location selected

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -1,0 +1,71 @@
+name: Test Frontend
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+
+defaults:
+  run:
+    working-directory: ./frontend
+
+jobs:
+  # test that frontend can build without issues
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install packages
+        run: bun install
+
+      - name: SSH debug
+        if: runner.debug == '1'
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Run test
+        run: bun run build
+
+  # test that frontend has no typescript errors
+  test-types:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install packages
+        run: bun install
+
+      - name: SSH debug
+        if: runner.debug == '1'
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Run test
+        run: bun run test:types
+
+  # test that frontend is properly formatted and linted
+  test-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install packages
+        run: bun install
+
+      - name: SSH debug
+        if: runner.debug == '1'
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Run test
+        run: bun run test:lint

--- a/frontend/src/pages/home/SectionMap.vue
+++ b/frontend/src/pages/home/SectionMap.vue
@@ -952,9 +952,9 @@ const locationOptions = computed(() => {
 /** are outreach locations selected */
 const outreachSelected = computed(() =>
   selectedLocations.value.filter((location) =>
-    Object.values(extraLocationList["Outreach and Interventions"]).includes(
-      location,
-    ),
+    (
+      Object.values(extraLocationList["Outreach and Interventions"]) as string[]
+    ).includes(location),
   ),
 );
 

--- a/frontend/src/pages/home/SectionMap.vue
+++ b/frontend/src/pages/home/SectionMap.vue
@@ -484,7 +484,7 @@
 
           <!-- outreach -->
 
-          <div class="mini-table">
+          <div v-if="outreachSelected.length" class="mini-table">
             <template v-if="feature.fit_kits">
               <AppLink
                 to="https://medlineplus.gov/ency/patientinstructions/000704.htm"
@@ -948,6 +948,15 @@ const locationOptions = computed(() => {
 
   return entries;
 });
+
+/** are outreach locations selected */
+const outreachSelected = computed(() =>
+  selectedLocations.value.filter((location) =>
+    Object.values(extraLocationList["Outreach and Interventions"]).includes(
+      location,
+    ),
+  ),
+);
 
 /** county overview outreach data */
 const countyWide = computed(() => {


### PR DESCRIPTION
- hide extra outreach info in county tooltip unless one or more outreach locations are selected
- add frontend test workflow on PRs (taken directly from molevolvr 2.0)