### PR TITLE
Updates scrape of legislative member HTML, other issues

### DIFF
--- a/data/pipeline/Snakefile
+++ b/data/pipeline/Snakefile
@@ -154,7 +154,7 @@ rule extract_cif_stats:
     input:
         f"{TARGET_DIR}/cif/us.zip",
     output:
-        f"{TARGET_DIR}/cif/stats/measure_dictionary_v5-2.csv",
+        f"{TARGET_DIR}/cif/stats/measure_dictionary_v5-3.csv",
         f"{TARGET_DIR}/cif/stats/RELEASE.txt",
         [ f"{TARGET_DIR}/cif/stats/{sheet}_long_DATE.csv" for sheet in CIF_EXPECTED_SHEETS ],
         f"{TARGET_DIR}/cif/stats/us_facilities_and_providers_DATE.csv",
@@ -190,7 +190,7 @@ rule extract_cif_stats:
 rule extract_cif_metadata:
     input:
         [ f"{TARGET_DIR}/cif/stats/{sheet}_long_DATE.csv" for sheet in CIF_EXPECTED_SHEETS ],
-        f"{TARGET_DIR}/cif/stats/measure_dictionary_v5-2.csv",
+        f"{TARGET_DIR}/cif/stats/measure_dictionary_v5-3.csv",
     output:
         f"{TARGET_DIR}/cif/cif_meta.json"
     shell:


### PR DESCRIPTION
Due to a change in the structure of the legislative members' page at https://leg.colorado.gov/legislators, the URL for the XLSX file failed to be extracted, causing the pipeline to abort.

Specifically, the text "Member Directory" located in the button on that page now occurs on a different line than the URL for the XLSX file; the `grep` statement that previously isolated the URL has been updated to look for the `.xlsx` extension directly, rather than the text of the button.

If this breaks again, we'll probably want to move to a full HTML parser that identifies the button, rather than using `grep` and `sed` to extract its href attribute.

This PR also introduces a small tweak to an expected filename in the CiF archive; previously it was `measure_dictionary_v5-2.csv` and now it's `measure_dictionary_v5-3.csv`. If they continue to change the filename, we should investigate making the dependency more flexible.