### PR TITLE
Fixes endpoint caching, makes more endpoints cached

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,8 @@ import aiomcache
 
 from routers import healthcheck, geometry, locations, statistics
 
+from tools.caching import request_key_builder
+
 from settings import IS_DEV, FRONTEND_DOMAIN
 
 # we'll just allow all origins for the time being
@@ -50,7 +52,10 @@ class HealthCheckFilter(logging.Filter):
 @app.on_event("startup")
 async def startup():
     mc = aiomcache.Client("memcached", 11211)
-    FastAPICache.init(MemcachedBackend(mc), prefix="fastapi-cache")
+    FastAPICache.init(
+        MemcachedBackend(mc), prefix="fastapi-cache",
+        key_builder=request_key_builder,
+    )
 
     # Remove /healthcheck from access logs
     logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())

--- a/backend/app/routers/geometry.py
+++ b/backend/app/routers/geometry.py
@@ -3,6 +3,7 @@ API endpoints that return geometry, e.g. county/tract boundaries.
 """
 
 from fastapi import Depends
+from fastapi_cache.decorator import cache
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -23,6 +24,7 @@ router = APIRouter()
 # ============================================================================
 
 @router.get("/counties", response_model=list[County])
+@cache()
 async def get_counties(session: AsyncSession = Depends(get_session)):
     """
     Returns metadata and geometry for counties. The geometry itself is in the
@@ -34,6 +36,7 @@ async def get_counties(session: AsyncSession = Depends(get_session)):
     return counties
 
 @router.get("/tracts", response_model=list[Tract])
+@cache()
 async def get_tracts(session: AsyncSession = Depends(get_session)):
     """
     Returns metadata and geometry for tracts. The geometry itself is in the
@@ -44,6 +47,7 @@ async def get_tracts(session: AsyncSession = Depends(get_session)):
     return tracts
 
 @router.get("/healthregions", response_model=list[HealthRegion])
+@cache()
 async def get_healthregions(session: AsyncSession = Depends(get_session)):
     """
     Returns metadata and geometry for health regions, combinations of counties

--- a/backend/app/routers/locations.py
+++ b/backend/app/routers/locations.py
@@ -4,6 +4,7 @@ and legislative district maps.
 """
 
 from fastapi import Depends
+from fastapi_cache.decorator import cache
 from pydantic import BaseModel
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -24,6 +25,7 @@ router = APIRouter()
 # ============================================================================
 
 @router.get("/locations", response_model=dict[str, dict[str, str]])
+@cache()
 async def get_location_categories(session: AsyncSession = Depends(get_session)):
     """
     Returns all location categories and IDs to associated locations.
@@ -47,6 +49,7 @@ async def get_location_categories(session: AsyncSession = Depends(get_session)):
     return response
 
 @router.get("/locations/by-category/{category_id}", response_model=list[Location])
+@cache()
 async def get_locations(category_id: str, session: AsyncSession = Depends(get_session)):
     """
     Returns all locations for a given category. The geometry itself is in the
@@ -63,6 +66,7 @@ async def get_locations(category_id: str, session: AsyncSession = Depends(get_se
     return locations
 
 @router.get("/locations/{location_id}", response_model=Location)
+@cache()
 async def get_location_by_id(location_id: str, session: AsyncSession = Depends(get_session)):
     """
     Returns specific locations by ID. The geometry itself is in the

--- a/backend/app/tools/caching.py
+++ b/backend/app/tools/caching.py
@@ -1,0 +1,31 @@
+from fastapi import Request
+from starlette.responses import Response
+
+def request_key_builder(
+    func,
+    namespace: str = "",
+    *,
+    request: Request = None,
+    response: Response = None,
+    **kwargs,
+) -> str:
+    """
+    This key builder builds a cache key based on the request method, path, and
+    query parameters.
+    
+    This is to circumvent the default key builder's behavior of using the
+    arguments to the method since in our case these are in-memory handles (like
+    database sessions) that are newly created with each request, causing a cache
+    miss every time.
+
+    Lifted from the docs, https://github.com/long2ice/fastapi-cache?tab=readme-ov-file#custom-key-builder.
+    """
+
+    return ":".join(
+        [
+            namespace,
+            (request.method.lower() if request else ""),
+            (request.url.path if request else ""),
+            repr(sorted(request.query_params.items())) if request else "",
+        ]
+    )


### PR DESCRIPTION
While the current ECCO stack includes components for caching requests, we were getting cache misses every time due to the fact that the library we're using, https://github.com/long2ice/fastapi-cache, uses hashed representations of the arguments to each function as the cache key. We pass a database handle to most endpoints that's recreated on each request, which means a new request can never match the cache.

Instead, [per the advice of the caching library docs](https://github.com/long2ice/fastapi-cache?tab=readme-ov-file#custom-key-builder), I've changed the key builder to one that uses just the request method, path, and query parameters to construct the cache key. This leads to demonstrably faster retrieval times for the cached endpoints -- `/locations`, for example, went from ~7 seconds to ~70ms.

This PR adds the `@cache` decorator to the geometry and locations endpoints, and should fix the existing cache decorations on the `/measures` and `/by-county/<FIPS>` endpoints.

On cache eviction/staleness: The cache we use is an in-memory cache held in `memcached`, so it's evicted whenever the stack is restarted. This occurs whenever we do a redeploy, usually triggered by a merge into `main`. Since the database is read-only, the response would only change if there were code and/or database changes, both of which can only occur after the stack is restarted.