### PR TITLE
fix compare map legends

### DIFF
--- a/frontend/src/pages/home/SectionMap.vue
+++ b/frontend/src/pages/home/SectionMap.vue
@@ -388,12 +388,14 @@
           <template #top-left-upper>
             <strong>
               {{
-                facets[selectedLevel]?.categories?.[selectedCategory]
-                  ?.measures?.[selectedMeasure]?.label
+                facets[selected.level]?.categories?.[selected.category]
+                  ?.measures?.[selected.measure]?.label
               }}
             </strong>
             <div>
-              {{ facets[selectedLevel]?.categories?.[selectedCategory]?.label }}
+              {{
+                facets[selected.level]?.categories?.[selected.category]?.label
+              }}
             </div>
             <div>
               {{


### PR DESCRIPTION
When using the compare feature, the map legend was still always using the "main" selected measure instead of each selected compared measure.

[Current (bugged)](https://coe-ecco.org/?level=county&category=scpincidence&measure=Thyroid&zoom=6.88996&lat=38.42092&long=-105.41713&compare=%5B%7B%22level%22%3A%22county%22%2C%22category%22%3A%22scpincidence%22%2C%22measure%22%3A%22Bladder%22%2C%22factors%22%3A%7B%22sex%22%3A%22All%22%2C%22stage%22%3A%22All+Stages%22%2C%22race%22%3A%22All+Races+%28includes+Hispanic%29%22%2C%22age%22%3A%22All+Ages%22%7D%2C%22locations%22%3A%5B%5D%7D%2C%7B%22level%22%3A%22county%22%2C%22category%22%3A%22scpincidence%22%2C%22measure%22%3A%22Prostate%22%2C%22factors%22%3A%7B%22sex%22%3A%22Male%22%2C%22stage%22%3A%22All+Stages%22%2C%22race%22%3A%22All+Races+%28includes+Hispanic%29%22%2C%22age%22%3A%22All+Ages%22%7D%2C%22locations%22%3A%5B%5D%7D%2C%7B%22level%22%3A%22county%22%2C%22category%22%3A%22scpincidence%22%2C%22measure%22%3A%22Thyroid%22%2C%22factors%22%3A%7B%22sex%22%3A%22All%22%2C%22stage%22%3A%22All+Stages%22%2C%22race%22%3A%22All+Races+%28includes+Hispanic%29%22%2C%22age%22%3A%22All+Ages%22%7D%2C%22locations%22%3A%5B%5D%7D%5D)

[Fixed](https://deploy-preview-170--exploring-cancer-in-colorado.netlify.app/?level=county&category=scpincidence&measure=Thyroid&zoom=6.88996&lat=38.42092&long=-105.41713&compare=%5B%7B%22level%22%3A%22county%22%2C%22category%22%3A%22scpincidence%22%2C%22measure%22%3A%22Bladder%22%2C%22factors%22%3A%7B%22sex%22%3A%22All%22%2C%22stage%22%3A%22All+Stages%22%2C%22race%22%3A%22All+Races+%28includes+Hispanic%29%22%2C%22age%22%3A%22All+Ages%22%7D%2C%22locations%22%3A%5B%5D%7D%2C%7B%22level%22%3A%22county%22%2C%22category%22%3A%22scpincidence%22%2C%22measure%22%3A%22Prostate%22%2C%22factors%22%3A%7B%22sex%22%3A%22Male%22%2C%22stage%22%3A%22All+Stages%22%2C%22race%22%3A%22All+Races+%28includes+Hispanic%29%22%2C%22age%22%3A%22All+Ages%22%7D%2C%22locations%22%3A%5B%5D%7D%2C%7B%22level%22%3A%22county%22%2C%22category%22%3A%22scpincidence%22%2C%22measure%22%3A%22Thyroid%22%2C%22factors%22%3A%7B%22sex%22%3A%22All%22%2C%22stage%22%3A%22All+Stages%22%2C%22race%22%3A%22All+Races+%28includes+Hispanic%29%22%2C%22age%22%3A%22All+Ages%22%7D%2C%22locations%22%3A%5B%5D%7D%5D)
